### PR TITLE
Feature/extend require validation capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,47 @@ user.name = 'Scott Hovestadt';
 { name: 'Scott Hovestadt' }
 ```
 
+## allowFalsyValues
+
+allowFalsyValues (default: true) allows you to specify what happens when an index is required by the schema, but a falsy value is provided. If allowFalsyValues is true, all falsy values, such as empty strings are ignored. If false, falsy values other than booleans will result in an error.
+
+With allowFalsyValues mode on (default):
+```js
+var Profile = new SchemaObject({
+  id: {
+    type: String,
+    required: true
+}, {
+  allowFalsyValues: true
+});
+
+var profile = new Profile();
+profile.id = '';
+
+console.log(profile.getErrors());
+// Prints:
+[]
+```
+
+With allowFalsyValues mode off:
+```js
+var Profile = new SchemaObject({
+  id: {
+    type: String,
+    required: true
+}, {
+  allowFalsyValues: false
+});
+
+var profile = new Profile();
+profile.id = '';
+
+console.log(profile.getErrors());
+// Prints:
+[ SetterError {
+    errorMessage: 'id is required but not provided'
+    ...
+```
 
 # Errors
 
@@ -613,7 +654,38 @@ If true, a value must be provided. If a value is not provided, an error will be 
 ```js
 fullName: {type: String, required: true}
 ```
-
+Required can also be a function, you can use 'this' to reference the current object instance. Required will be based on what boolean value the function returns.
+```js
+age: {
+  type: Number,
+  required: true
+},
+employer: {
+  type: String,
+  required: function() {
+    return this.age > 18;
+  }
+}
+```
+You can also override the default error message for required fields by using an array and providing a string for the second value.
+```js
+age: {
+  type: Number,
+  required: [
+    true,
+    'You must provide the age of this user'
+  ]
+},
+employer: {
+  type: String,
+  required: [
+    function() {
+      return this.age > 18;
+    },
+    'An employer is required for all users over the age of 18'
+  ]
+}
+```
 ### readOnly
 If true, the value can be read but cannot be written to. This can be useful for creating fields that reflect other values.
 ```js

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -697,7 +697,10 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             keysIgnoreCase: false,
 
             // Inherit root object "this" context from parent SchemaObject.
-            inheritRootThis: false
+            inheritRootThis: false,
+
+            // If this is set to false, require will not allow falsy values such as empty strings
+            allowFalsyValues: true
         }, options);
 
         // Some of the options require reflection.
@@ -883,94 +886,92 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                 // Without Proxy we must register individual getter/typecasts to put any logic in place.
                 // With Proxy, we still use the individual getter/typecasts, but also catch values that aren't in the schema.
                 if (_isProxySupported === true) {
-                    (function () {
-                        var proxy = _this6[_privateKey]._this = new Proxy(_this6, {
-                            // Ensure only public keys are shown.
-                            ownKeys: function ownKeys(target) {
-                                return Object.keys(_this6.toObject());
-                            },
+                    var proxy = this[_privateKey]._this = new Proxy(this, {
+                        // Ensure only public keys are shown.
+                        ownKeys: function ownKeys(target) {
+                            return Object.keys(_this6.toObject());
+                        },
 
-                            // Return keys to iterate.
-                            enumerate: function enumerate(target) {
-                                return Object.keys(_this6[_privateKey]._this)[Symbol.iterator]();
-                            },
+                        // Return keys to iterate.
+                        enumerate: function enumerate(target) {
+                            return Object.keys(_this6[_privateKey]._this)[Symbol.iterator]();
+                        },
 
-                            // Check to see if key exists.
-                            has: function has(target, key) {
-                                return !!_private._getset[key];
-                            },
+                        // Check to see if key exists.
+                        has: function has(target, key) {
+                            return !!_private._getset[key];
+                        },
 
-                            // Ensure correct prototype is returned.
-                            getPrototypeOf: function getPrototypeOf() {
-                                return _private._getset;
-                            },
+                        // Ensure correct prototype is returned.
+                        getPrototypeOf: function getPrototypeOf() {
+                            return _private._getset;
+                        },
 
-                            // Ensure readOnly fields are not writeable.
-                            getOwnPropertyDescriptor: function getOwnPropertyDescriptor(target, key) {
-                                return {
-                                    value: proxy[key],
-                                    writeable: !schema[key] || schema[key].readOnly !== true,
-                                    enumerable: true,
-                                    configurable: true
-                                };
-                            },
+                        // Ensure readOnly fields are not writeable.
+                        getOwnPropertyDescriptor: function getOwnPropertyDescriptor(target, key) {
+                            return {
+                                value: proxy[key],
+                                writeable: !schema[key] || schema[key].readOnly !== true,
+                                enumerable: true,
+                                configurable: true
+                            };
+                        },
 
-                            // Intercept all get calls.
-                            get: function get(target, name, receiver) {
-                                // First check to see if it's a reserved field.
-                                if (_reservedFields.includes(name)) {
-                                    return _this6[_privateKey]._reservedFields[name];
-                                }
-
-                                // Support dot notation via lodash.
-                                if (options.dotNotation && name.indexOf('.') !== -1) {
-                                    return _.get(_this6[_privateKey]._this, name);
-                                }
-
-                                // Use registered getter without hitting the proxy to avoid creating an infinite loop.
-                                return _this6[name];
-                            },
-
-                            // Intercept all set calls.
-                            set: function set(target, name, value, receiver) {
-                                // Support dot notation via lodash.
-                                if (options.dotNotation && name.indexOf('.') !== -1) {
-                                    return _.set(_this6[_privateKey]._this, name, value);
-                                }
-
-                                // Find real keyname if case sensitivity is off.
-                                if (options.keysIgnoreCase && !schema[name]) {
-                                    name = getIndex.call(_this6, name);
-                                }
-
-                                if (!schema[name]) {
-                                    if (options.strict) {
-                                        // Strict mode means we don't want to deal with anything not in the schema.
-                                        // TODO: SetterError here.
-                                        return true;
-                                    } else {
-                                        // Add index to schema dynamically when value is set.
-                                        // This is necessary for toObject to see the field.
-                                        addToSchema.call(_this6, name, {
-                                            type: 'any'
-                                        });
-                                    }
-                                }
-
-                                // This hits the registered setter but bypasses the proxy to avoid an infinite loop.
-                                _this6[name] = value;
-
-                                // Necessary for Node v6.0. Prevents error: 'set' on proxy: trap returned falsish for property 'string'".
-                                return true;
-                            },
-
-                            // Intercept all delete calls.
-                            deleteProperty: function deleteProperty(target, property) {
-                                _this6[property] = undefined;
-                                return true;
+                        // Intercept all get calls.
+                        get: function get(target, name, receiver) {
+                            // First check to see if it's a reserved field.
+                            if (_reservedFields.includes(name)) {
+                                return _this6[_privateKey]._reservedFields[name];
                             }
-                        });
-                    })();
+
+                            // Support dot notation via lodash.
+                            if (options.dotNotation && name.indexOf('.') !== -1) {
+                                return _.get(_this6[_privateKey]._this, name);
+                            }
+
+                            // Use registered getter without hitting the proxy to avoid creating an infinite loop.
+                            return _this6[name];
+                        },
+
+                        // Intercept all set calls.
+                        set: function set(target, name, value, receiver) {
+                            // Support dot notation via lodash.
+                            if (options.dotNotation && name.indexOf('.') !== -1) {
+                                return _.set(_this6[_privateKey]._this, name, value);
+                            }
+
+                            // Find real keyname if case sensitivity is off.
+                            if (options.keysIgnoreCase && !schema[name]) {
+                                name = getIndex.call(_this6, name);
+                            }
+
+                            if (!schema[name]) {
+                                if (options.strict) {
+                                    // Strict mode means we don't want to deal with anything not in the schema.
+                                    // TODO: SetterError here.
+                                    return true;
+                                } else {
+                                    // Add index to schema dynamically when value is set.
+                                    // This is necessary for toObject to see the field.
+                                    addToSchema.call(_this6, name, {
+                                        type: 'any'
+                                    });
+                                }
+                            }
+
+                            // This hits the registered setter but bypasses the proxy to avoid an infinite loop.
+                            _this6[name] = value;
+
+                            // Necessary for Node v6.0. Prevents error: 'set' on proxy: trap returned falsish for property 'string'".
+                            return true;
+                        },
+
+                        // Intercept all delete calls.
+                        deleteProperty: function deleteProperty(target, property) {
+                            _this6[property] = undefined;
+                            return true;
+                        }
+                    });
                 }
 
                 // Populate schema defaults into object.
@@ -1127,11 +1128,31 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                     }
 
                     _.each(this[_privateKey]._schema, function (properties, index) {
-                        if (properties.required && _this9[index] === undefined) {
-                            var error = new SetterError(index + ' is required but not provided', _this9[index], _this9[index], properties);
-                            error.schemaObject = _this9;
-                            errors.push(error);
+                        var required = properties.required;
+                        var message = index + ' is required but not provided';
+
+                        //If required is an array, set custom message
+                        if (Array.isArray(required)) {
+                            message = required[1] || message;
+                            required = required[0];
                         }
+                        //Skip if required does not exist
+                        if (!required) {
+                            return;
+                        }
+                        //Skip if required is a function, but returns false
+                        else if (typeof required === 'function' && !required.call(_this9)) {
+                                return;
+                            }
+
+                        //If property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
+                        if (_this9[index] || typeof _this9[index] === 'boolean' || _this9[_privateKey]._options.allowFalsyValues && _this9[index] !== undefined) {
+                            return;
+                        }
+
+                        var error = new SetterError(message, _this9[index], _this9[index], properties);
+                        error.schemaObject = _this9;
+                        errors.push(error);
                     });
 
                     // Look for sub-SchemaObjects.

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -1145,7 +1145,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                                 return;
                             }
 
-                        //If property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
+                        //Skip if property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
                         if (_this9[index] || typeof _this9[index] === 'boolean' || _this9[_privateKey]._options.allowFalsyValues && _this9[index] !== undefined) {
                             return;
                         }

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -984,7 +984,7 @@
                         return;
                     }
 
-                    //If property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
+                    //Skip if property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
                     if (
                       this[index] ||
                       typeof this[index] === 'boolean' ||

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -623,7 +623,10 @@
                 keysIgnoreCase: false,
 
                 // Inherit root object "this" context from parent SchemaObject.
-                inheritRootThis: false
+                inheritRootThis: false,
+
+                // If this is set to false, require will not allow falsy values such as empty strings
+                allowFalsyValues: true
             }, options);
 
             // Some of the options require reflection.
@@ -964,11 +967,35 @@
                 }
 
                 _.each(this[_privateKey]._schema, (properties, index) => {
-                    if (properties.required && this[index] === undefined) {
-                        const error = new SetterError(`${index} is required but not provided`, this[index], this[index], properties);
-                        error.schemaObject = this;
-                        errors.push(error);
+                    let required = properties.required;
+                    let message = `${index} is required but not provided`;
+
+                    //If required is an array, set custom message
+                    if (Array.isArray(required)) {
+                      message = required[1] || message;
+                      required = required[0];
                     }
+                    //Skip if required does not exist
+                    if (!required) {
+                        return;
+                    }
+                    //Skip if required is a function, but returns false
+                    else if (typeof required === 'function' && !required.call(this)) {
+                        return;
+                    }
+
+                    //If property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
+                    if (
+                      this[index] ||
+                      typeof this[index] === 'boolean' ||
+                      this[_privateKey]._options.allowFalsyValues && this[index] !== undefined
+                    ) {
+                      return;
+                    }
+
+                    const error = new SetterError(message, this[index], this[index], properties);
+                    error.schemaObject = this;
+                    errors.push(error);
                 });
 
                 // Look for sub-SchemaObjects.

--- a/test/tests.js
+++ b/test/tests.js
@@ -646,6 +646,36 @@ describe('any type', function () {
             o.isErrors().should.equal(true);
         });
 
+        it('should reject if field required function returns true', function () {
+          var SO = new SchemaObject({
+            name: {
+              type: String,
+              required: function() {
+                return true;
+              }
+            }
+          });
+  
+          var o = new SO();
+          o.getErrors().length.should.equal(1);
+          o.isErrors().should.equal(true);
+        });
+  
+        it('should not reject if field required function returns false', function () {
+          var SO = new SchemaObject({
+            name: {
+              type: String,
+              required: function() {
+                return false;
+              }
+            }
+          });
+  
+          var o = new SO();
+          o.getErrors().length.should.equal(0);
+          o.isErrors().should.equal(false);
+        });
+
         it('should not reject if field is required but default provided', function () {
             var SO = new SchemaObject({
                 name: {
@@ -669,7 +699,7 @@ describe('any type', function () {
             });
 
             var o = new SO();
-            o.name = 'Andy & Scott'
+            o.name = 'Andy & Scott';
 
             o.getErrors().length.should.equal(0);
             o.isErrors().should.equal(false);
@@ -690,6 +720,42 @@ describe('any type', function () {
             o.isErrors().should.equal(false);
         });
 
+        it('should reject if field is required and a falsy value is provided and allowFalsyValues is false', function () {
+          var SO = new SchemaObject({
+            name: {
+              type: String,
+              required: true
+            }
+          }, {
+            allowFalsyValues: false
+          });
+  
+          var o = new SO();
+          o.name = '';
+  
+          o.getErrors().length.should.equal(1);
+          o.isErrors().should.equal(true);
+        });
+
+      it('should not reject if field is required and a boolean false value is provided and allowFalsyValues is false', function () {
+        var SO = new SchemaObject({
+          myBoolean: {
+            type: Boolean,
+            required: true
+          }
+        }, {
+          allowFalsyValues: false
+        });
+
+        var o = new SO();
+        o.myBoolean = false;
+
+        o.getErrors().length.should.equal(0);
+        o.isErrors().should.equal(false);
+        should.exist(o.toObject().myBoolean);
+        o.toObject().myBoolean.should.equal(false);
+      });
+
         it('should reject if field is required, provided, and then removed', function () {
             var SO = new SchemaObject({
                 name: {
@@ -699,7 +765,7 @@ describe('any type', function () {
             });
 
             var o = new SO();
-            o.name = 'Andy & Scott'
+            o.name = 'Andy & Scott';
             o.getErrors().length.should.equal(0);
             o.isErrors().should.equal(false);
             o.name = undefined; 

--- a/test/tests.js
+++ b/test/tests.js
@@ -737,24 +737,24 @@ describe('any type', function () {
           o.isErrors().should.equal(true);
         });
 
-      it('should not reject if field is required and a boolean false value is provided and allowFalsyValues is false', function () {
-        var SO = new SchemaObject({
-          myBoolean: {
-            type: Boolean,
-            required: true
-          }
-        }, {
-          allowFalsyValues: false
+        it('should not reject if field is required and a boolean false value is provided and allowFalsyValues is false', function () {
+          var SO = new SchemaObject({
+            myBoolean: {
+              type: Boolean,
+              required: true
+            }
+          }, {
+            allowFalsyValues: false
+          });
+
+          var o = new SO();
+          o.myBoolean = false;
+
+          o.getErrors().length.should.equal(0);
+          o.isErrors().should.equal(false);
+          should.exist(o.toObject().myBoolean);
+          o.toObject().myBoolean.should.equal(false);
         });
-
-        var o = new SO();
-        o.myBoolean = false;
-
-        o.getErrors().length.should.equal(0);
-        o.isErrors().should.equal(false);
-        should.exist(o.toObject().myBoolean);
-        o.toObject().myBoolean.should.equal(false);
-      });
 
         it('should reject if field is required, provided, and then removed', function () {
             var SO = new SchemaObject({


### PR DESCRIPTION
These changes allow much more extensive use of the 'required' flag on the schema. The first added capability is function-based required statements, to allow for conditionally required fields. For example:

```js
age: {
  type: Number,
  required: true
},
employer: {
  type: String,
  required: function() {
    return this.age > 18;
  }
}
```

Next, we also allow for specifying a custom error message for failing the required check by using an array, which is very useful when conditional require statements are being used. Example:

```js
age: {
  type: Number,
  required: [true, 'You must provide the age of this user']
},
employer: {
  type: String,
  required: [
    function() {
      return this.age > 18;
    },
    'An employer is required for all users over the age of 18'
  ]
}
```

Lastly, a new configuration option allows the schema to error on falsy values such as empty strings. The default has been left to match existing functionality.

```js
var Profile = new SchemaObject({
  id: {
    type: String,
    required: true
}, {
  allowFalsyValues: false
});

var profile = new Profile();
profile.id = '';

console.log(profile.getErrors());
// Prints:
[ SetterError {
    errorMessage: 'id is required but not provided'
    ...
```

Tests have been added to check this new functionality, as well as documentation for it in the Readme. I did notice that upon executing a build of the script I seem to get a slightly different output structure which is missing the self-invoking wrapper around the proxy section. Please let me know if that is an issue.