### PR TITLE
Feature/better validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,17 +637,17 @@ profile.clearErrors();
 
 Each error type has an error code. Here is a map of them, however this may be out of date if someone adds an error without updating this list.
 
-* [1000] Setter Error
-  * [1100] Cast Error
-    * [1101] String Cast Error
-    * [1102] Number Cast Error
-    * [1103] Array Cast Error
-    * [1104] Object Cast Error
-    * [1105] Date Cast Error
-  * [1200] Validation Error
-    * [1210] String Validation Error
-      * [1211] String Enum Validation Error
-      * [1212] String Min Length Validation Error
+* [1000] SetterError
+  * [1100] CastError
+    * [1101] StringCastError
+    * [1102] NumberCastError
+    * [1103] ArrayCastError
+    * [1104] ObjectCastError
+    * [1105] DateCastError
+  * [1200] ValidationError
+    * [1210] StringValidationError
+      * [1211] StringEnumValidationError
+      * [1212] StringMinLengthValidationError
       * [1213] StringMaxLengthValidationError
       * [1214] StringRegexValidationError
     * [1220] NumberValidationError

--- a/README.md
+++ b/README.md
@@ -574,6 +574,37 @@ console.log(profile.getErrors());
     ...
 ```
 
+## useDecimalNumberGroupSeparator
+useDecimalNumberGroupSeparator (default: false) defines the digit group separator used for parsing numbers. When left false, numbers are expected to use `,` as a digit separator. For example 3,043,201.01. However this options is enabled it swaps commas and decimals to allow parsing numbers like 3.043.201,01. This is to allow for usability in countries which use this format instead.
+
+With useDecimalNumberGroupSeparator mode off (default):
+```js
+var Profile = new SchemaObject({
+  id: String,
+  followers: Number
+});
+var profile = new Profile({ followers: '124.423.123,87'});
+console.log(profile.followers); //undefined
+
+profile = new Profile({ followers: '124,423,123.87'});
+console.log(profile.followers); //124423123.87
+```
+
+With useDecimalNumberGroupSeparator mode on:
+```js
+var Profile = new SchemaObject({
+  id: String,
+  followers: Number
+}, {
+  useDecimalNumberGroupSeparator: true
+});
+var profile = new Profile({ followers: '124.423.123,87'});
+console.log(profile.followers); //124423123.87
+
+profile = new Profile({ followers: '124,423,123.87'});
+console.log(profile.followers); //undefined
+```
+
 # Errors
 
 When setting a value fails, an error is generated silently. Errors can be retrieved with getErrors() and cleared with clearErrors().
@@ -602,7 +633,63 @@ console.log(profile.getErrors());
 // Clear all errors.
 profile.clearErrors();
 ```
+## Error codes
 
+Each error type has an error code. Here is a map of them, however this may be out of date if someone adds an error without updating this list.
+
+* [1000] Setter Error
+  * [1100] Cast Error
+    * [1101] String Cast Error
+    * [1102] Number Cast Error
+    * [1103] Array Cast Error
+    * [1104] Object Cast Error
+    * [1105] Date Cast Error
+  * [1200] Validation Error
+    * [1210] String Validation Error
+      * [1211] String Enum Validation Error
+      * [1212] String Min Length Validation Error
+      * [1213] StringMaxLengthValidationError
+      * [1214] StringRegexValidationError
+    * [1220] NumberValidationError
+      * [1221] NumberMinValidationError
+      * [1222] NumberMaxValidationError
+    * [1230] DateValidationError
+      * [1231] DateParseValidationError
+
+## Custom Errors
+
+You can also set custom errors for all validators. There are currently two supported formats for this.
+
+### Array Error Format
+
+The array format expects the validator value as the first argument, and the error message as the second argument.
+Here is an example:
+```js
+var Profile = new SchemaObject({
+  id: {
+    type: String,
+    minLength: [5, 'id length must be longer than 5 characters']
+  }
+});
+```
+
+### Object Error Format
+
+The object format expects an object with two keys, `value` is the validator value, and `errorMessage` is the custom error message.
+Here is an example:
+```js
+var Profile = new SchemaObject({
+  id: {
+    type: String,
+    minLength: {
+      value: 5,
+      errorMessage: 'id length must be longer than 5 characters'
+    }
+  }
+});
+```
+
+Both of these formats can be used interchangeably.
 
 # Types
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ console.log(profile.getErrors());
 ```
 
 ## useDecimalNumberGroupSeparator
-useDecimalNumberGroupSeparator (default: false) defines the digit group separator used for parsing numbers. When left false, numbers are expected to use `,` as a digit separator. For example 3,043,201.01. However this options is enabled it swaps commas and decimals to allow parsing numbers like 3.043.201,01. This is to allow for usability in countries which use this format instead.
+useDecimalNumberGroupSeparator (default: false) defines the digit group separator used for parsing numbers. When left false, numbers are expected to use `,` as a digit separator. For example 3,043,201.01. However when this options is enabled it swaps commas and decimals to allow parsing numbers like 3.043.201,01. This is to allow for usability in countries which use this format instead.
 
 With useDecimalNumberGroupSeparator mode off (default):
 ```js

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -4,10 +4,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 function _extendableBuiltin(cls) {
     function ExtendableBuiltin() {
         var instance = Reflect.construct(cls, Array.from(arguments));
@@ -32,6 +28,10 @@ function _extendableBuiltin(cls) {
 
     return ExtendableBuiltin;
 }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -136,11 +136,293 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
         this.fieldSchema = fieldSchema;
     };
 
+    var CastError = function (_SetterError) {
+        _inherits(CastError, _SetterError);
+
+        function CastError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, CastError);
+
+            var _this = _possibleConstructorReturn(this, (CastError.__proto__ || Object.getPrototypeOf(CastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this.errorType = 'CastError';
+            _this.errorCode = 1000;
+            return _this;
+        }
+
+        return CastError;
+    }(SetterError);
+
+    var ValidationError = function (_SetterError2) {
+        _inherits(ValidationError, _SetterError2);
+
+        function ValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, ValidationError);
+
+            var _this2 = _possibleConstructorReturn(this, (ValidationError.__proto__ || Object.getPrototypeOf(ValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this2.errorType = 'ValidationError';
+            _this2.errorCode = 2000;
+            return _this2;
+        }
+
+        return ValidationError;
+    }(SetterError);
+
+    var StringCastError = function (_CastError) {
+        _inherits(StringCastError, _CastError);
+
+        function StringCastError(setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringCastError);
+
+            var errorMessage = 'String type cannot typecast Object or Array types.';
+
+            var _this3 = _possibleConstructorReturn(this, (StringCastError.__proto__ || Object.getPrototypeOf(StringCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this3.errorCode = 1001;
+            return _this3;
+        }
+
+        return StringCastError;
+    }(CastError);
+
+    var NumberCastError = function (_CastError2) {
+        _inherits(NumberCastError, _CastError2);
+
+        function NumberCastError(sourceType, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, NumberCastError);
+
+            var errorMessage = 'Number could not be typecast from the provided ' + sourceType;
+
+            var _this4 = _possibleConstructorReturn(this, (NumberCastError.__proto__ || Object.getPrototypeOf(NumberCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this4.errorCode = 1002;
+            return _this4;
+        }
+
+        return NumberCastError;
+    }(CastError);
+
+    var ArrayCastError = function (_CastError3) {
+        _inherits(ArrayCastError, _CastError3);
+
+        function ArrayCastError(setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, ArrayCastError);
+
+            var errorMessage = 'Array type cannot typecast non-Array types.';
+
+            var _this5 = _possibleConstructorReturn(this, (ArrayCastError.__proto__ || Object.getPrototypeOf(ArrayCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this5.errorCode = 1003;
+            return _this5;
+        }
+
+        return ArrayCastError;
+    }(CastError);
+
+    var ObjectCastError = function (_CastError4) {
+        _inherits(ObjectCastError, _CastError4);
+
+        function ObjectCastError(setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, ObjectCastError);
+
+            var errorMessage = 'Object type cannot typecast non-Object types.';
+
+            var _this6 = _possibleConstructorReturn(this, (ObjectCastError.__proto__ || Object.getPrototypeOf(ObjectCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this6.errorCode = 1004;
+            return _this6;
+        }
+
+        return ObjectCastError;
+    }(CastError);
+
+    var DateCastError = function (_CastError5) {
+        _inherits(DateCastError, _CastError5);
+
+        function DateCastError(setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, DateCastError);
+
+            var errorMessage = 'Date type cannot typecast Array or Object types.';
+
+            var _this7 = _possibleConstructorReturn(this, (DateCastError.__proto__ || Object.getPrototypeOf(DateCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this7.errorCode = 1005;
+            return _this7;
+        }
+
+        return DateCastError;
+    }(CastError);
+
+    var StringValidationError = function (_ValidationError) {
+        _inherits(StringValidationError, _ValidationError);
+
+        function StringValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringValidationError);
+
+            var _this8 = _possibleConstructorReturn(this, (StringValidationError.__proto__ || Object.getPrototypeOf(StringValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this8.errorCode = 2100;
+            return _this8;
+        }
+
+        return StringValidationError;
+    }(ValidationError);
+
+    var NumberValidationError = function (_ValidationError2) {
+        _inherits(NumberValidationError, _ValidationError2);
+
+        function NumberValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, NumberValidationError);
+
+            var _this9 = _possibleConstructorReturn(this, (NumberValidationError.__proto__ || Object.getPrototypeOf(NumberValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this9.errorCode = 2200;
+            return _this9;
+        }
+
+        return NumberValidationError;
+    }(ValidationError);
+
+    var DateValidationError = function (_ValidationError3) {
+        _inherits(DateValidationError, _ValidationError3);
+
+        function DateValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, DateValidationError);
+
+            var _this10 = _possibleConstructorReturn(this, (DateValidationError.__proto__ || Object.getPrototypeOf(DateValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this10.errorCode = 2300;
+            return _this10;
+        }
+
+        return DateValidationError;
+    }(ValidationError);
+
+    var StringEnumValidationError = function (_StringValidationErro) {
+        _inherits(StringEnumValidationError, _StringValidationErro);
+
+        function StringEnumValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringEnumValidationError);
+
+            errorMessage = errorMessage || 'String does not exist in enum list.';
+
+            var _this11 = _possibleConstructorReturn(this, (StringEnumValidationError.__proto__ || Object.getPrototypeOf(StringEnumValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this11.errorCode = 2101;
+            return _this11;
+        }
+
+        return StringEnumValidationError;
+    }(StringValidationError);
+
+    var StringMinLengthValidationError = function (_StringValidationErro2) {
+        _inherits(StringMinLengthValidationError, _StringValidationErro2);
+
+        function StringMinLengthValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringMinLengthValidationError);
+
+            errorMessage = errorMessage || 'String length too short to meet minLength requirement.';
+
+            var _this12 = _possibleConstructorReturn(this, (StringMinLengthValidationError.__proto__ || Object.getPrototypeOf(StringMinLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this12.errorCode = 2102;
+            return _this12;
+        }
+
+        return StringMinLengthValidationError;
+    }(StringValidationError);
+
+    var StringMaxLengthValidationError = function (_StringValidationErro3) {
+        _inherits(StringMaxLengthValidationError, _StringValidationErro3);
+
+        function StringMaxLengthValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringMaxLengthValidationError);
+
+            errorMessage = errorMessage || 'String length too long to meet maxLength requirement.';
+
+            var _this13 = _possibleConstructorReturn(this, (StringMaxLengthValidationError.__proto__ || Object.getPrototypeOf(StringMaxLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this13.errorCode = 2103;
+            return _this13;
+        }
+
+        return StringMaxLengthValidationError;
+    }(StringValidationError);
+
+    var StringRegexValidationError = function (_StringValidationErro4) {
+        _inherits(StringRegexValidationError, _StringValidationErro4);
+
+        function StringRegexValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, StringRegexValidationError);
+
+            errorMessage = errorMessage || 'String does not match regular expression pattern.';
+
+            var _this14 = _possibleConstructorReturn(this, (StringRegexValidationError.__proto__ || Object.getPrototypeOf(StringRegexValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this14.errorCode = 2104;
+            return _this14;
+        }
+
+        return StringRegexValidationError;
+    }(StringValidationError);
+
+    var NumberMinValidationError = function (_NumberValidationErro) {
+        _inherits(NumberMinValidationError, _NumberValidationErro);
+
+        function NumberMinValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, NumberMinValidationError);
+
+            errorMessage = errorMessage || 'Number is too small to meet min requirement.';
+
+            var _this15 = _possibleConstructorReturn(this, (NumberMinValidationError.__proto__ || Object.getPrototypeOf(NumberMinValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this15.errorCode = 2201;
+            return _this15;
+        }
+
+        return NumberMinValidationError;
+    }(NumberValidationError);
+
+    var NumberMaxValidationError = function (_NumberValidationErro2) {
+        _inherits(NumberMaxValidationError, _NumberValidationErro2);
+
+        function NumberMaxValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, NumberMaxValidationError);
+
+            errorMessage = errorMessage || 'Number is too big to meet max requirement.';
+
+            var _this16 = _possibleConstructorReturn(this, (NumberMaxValidationError.__proto__ || Object.getPrototypeOf(NumberMaxValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this16.errorCode = 2202;
+            return _this16;
+        }
+
+        return NumberMaxValidationError;
+    }(NumberValidationError);
+
+    var DateParseValidationError = function (_DateValidationError) {
+        _inherits(DateParseValidationError, _DateValidationError);
+
+        function DateParseValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, DateParseValidationError);
+
+            errorMessage = errorMessage || 'Could not parse date.';
+
+            var _this17 = _possibleConstructorReturn(this, (DateParseValidationError.__proto__ || Object.getPrototypeOf(DateParseValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this17.errorCode = 2301;
+            return _this17;
+        }
+
+        return DateParseValidationError;
+    }(DateValidationError);
+
     // Returns typecasted value if possible. If rejected, originalValue is returned.
 
 
     function typecast(value, originalValue, properties) {
         var options = this[_privateKey]._options;
+        var customError = void 0;
 
         // Allow transform to manipulate raw properties.
         if (properties.transform) {
@@ -152,12 +434,22 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             return null;
         }
 
+        // Helper function designed to detect and handle usage of array-form custom error messages for validators
+        function detectCustomErrorMessage(key) {
+            if (_.isArray(properties[key])) {
+                customError = properties[key][1];
+                properties[key] = properties[key][0];
+            } else {
+                customError = undefined;
+            }
+        }
+
         // Property types are always normalized as lowercase strings despite shorthand definitions being available.
         switch (properties.type) {
             case 'string':
                 // Reject if object or array.
                 if (_.isObject(value) || _.isArray(value)) {
-                    throw new SetterError('String type cannot typecast Object or Array types.', value, originalValue, properties);
+                    throw new StringCastError(value, originalValue, properties);
                 }
 
                 // If index is being set with null or undefined, set value and end.
@@ -180,24 +472,39 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                     value = value.substr(0, properties.maxLength);
                 }
 
+                // Detect custom error message usage for enum (can't use function here as enum is expected to be an array)
+                if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
+                    customError = properties.enum[1];
+                    properties.enum = properties.enum[0];
+                }
+
                 // If enum is being used, be sure the value is within definition.
                 if (_.isArray(properties.enum) && properties.enum.indexOf(value) === -1) {
-                    throw new SetterError('String does not exist in enum list.', value, originalValue, properties);
+                    throw new StringEnumValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for minLength
+                detectCustomErrorMessage('minLength');
 
                 // If minLength is defined, check to be sure the string is > minLength.
                 if (properties.minLength !== undefined && value.length < properties.minLength) {
-                    throw new SetterError('String length too short to meet minLength requirement.', value, originalValue, properties);
+                    throw new StringMinLengthValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for maxLength
+                detectCustomErrorMessage('maxLength');
 
                 // If maxLength is defined, check to be sure the string is < maxLength.
                 if (properties.maxLength !== undefined && value.length > properties.maxLength) {
-                    throw new SetterError('String length too long to meet maxLength requirement.', value, originalValue, properties);
+                    throw new StringMaxLengthValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for maxLength
+                detectCustomErrorMessage('regex');
 
                 // If regex is defined, check to be sure the string matches the regex pattern.
                 if (properties.regex && !properties.regex.test(value)) {
-                    throw new SetterError('String does not match regular expression pattern.', value, originalValue, properties);
+                    throw new StringRegexValidationError(customError, value, originalValue, properties);
                 }
 
                 return value;
@@ -215,28 +522,43 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // Remove comma from strings.
                 if (typeof value === 'string') {
-                    value = value.replace(/,/g, '');
+                    value = value.replace(new RegExp(options.numberGroupSeparator, 'g'), '');
+
+                    // Reject if string was not a valid number
+                    if (isNaN(Number(value))) {
+                        throw new NumberCastError('String', value, originalValue, properties);
+                    }
                 }
 
                 // Reject if array, object, or not numeric.
-                if (_.isArray(value) || _.isObject(value) || !isNumeric(value)) {
-                    throw new SetterError('Number type cannot typecast Array or Object types.', value, originalValue, properties);
+                if (_.isArray(value)) {
+                    throw new NumberCastError('Array', value, originalValue, properties);
+                } else if (_.isObject(value)) {
+                    throw new NumberCastError('Object', value, originalValue, properties);
+                } else if (!isNumeric(value)) {
+                    throw new NumberCastError('Non-numeric', value, originalValue, properties);
                 }
 
                 // Typecast to number.
-                value = value * 1;
+                value = Number(value);
 
                 // Transformation after typecasting but before validation and filters.
                 if (properties.numberTransform) {
                     value = properties.numberTransform.call(this[_privateKey]._root, value, originalValue, properties);
                 }
 
+                // Detect custom error message usage for min
+                detectCustomErrorMessage('min');
+
                 if (properties.min !== undefined && value < properties.min) {
-                    throw new SetterError('Number is too small to meet min requirement.', value, originalValue, properties);
+                    throw new NumberMinValidationError(customError, value, originalValue, properties);
                 }
 
+                // Detect custom error message usage for min
+                detectCustomErrorMessage('max');
+
                 if (properties.max !== undefined && value > properties.max) {
-                    throw new SetterError('Number is too big to meet max requirement.', value, originalValue, properties);
+                    throw new NumberMaxValidationError(customError, value, originalValue, properties);
                 }
 
                 return value;
@@ -254,11 +576,11 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // If is Number, <0 is true and >0 is false.
                 if (isNumeric(value)) {
-                    return value * 1 > 0 ? true : false;
+                    return value * 1 > 0;
                 }
 
                 // Use Javascript to eval and return boolean.
-                value = value ? true : false;
+                value = !!value;
 
                 // Transformation after typecasting but before validation and filters.
                 if (properties.booleanTransform) {
@@ -275,7 +597,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // Reject if not array.
                 if (!_.isArray(value)) {
-                    throw new SetterError('Array type cannot typecast non-Array types.', value, originalValue, properties);
+                    throw new ArrayCastError(value, originalValue, properties);
                 }
 
                 // Arrays are never set directly.
@@ -291,7 +613,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             case 'object':
                 // If it's not an Object, reject.
                 if (!_.isObject(value)) {
-                    throw new SetterError('Object type cannot typecast non-Object types.', value, originalValue, properties);
+                    throw new ObjectCastError(value, originalValue, properties);
                 }
 
                 // If object is schema object and an entirely new object was passed, clear values and set.
@@ -328,7 +650,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // Reject if object, array or boolean.
                 if (!_.isDate(value) && !_.isString(value) && !_.isNumber(value)) {
-                    throw new SetterError('Date type cannot typecast Array or Object types.', value, originalValue, properties);
+                    throw new DateCastError(value, originalValue, properties);
                 }
 
                 // Attempt to parse string value with Date.parse (which returns number of milliseconds).
@@ -343,7 +665,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // If the date couldn't be parsed, do not modify index.
                 if (value == 'Invalid Date' || !_.isDate(value)) {
-                    throw new SetterError('Could not parse date.', value, originalValue, properties);
+                    throw new DateParseValidationError(customError, value, originalValue, properties);
                 }
 
                 // Transformation after typecasting but before validation and filters.
@@ -463,40 +785,40 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
     // Defines getter for specific field.
     function defineGetter(index, properties) {
-        var _this = this;
+        var _this18 = this;
 
         // If the field type is an alias, we retrieve the value through the alias's index.
         var indexOrAliasIndex = properties.type === 'alias' ? properties.index : index;
 
         this.__defineGetter__(index, function () {
             // If accessing object or array, lazy initialize if not set.
-            if (!_this[_privateKey]._obj[indexOrAliasIndex] && (properties.type === 'object' || properties.type === 'array')) {
+            if (!_this18[_privateKey]._obj[indexOrAliasIndex] && (properties.type === 'object' || properties.type === 'array')) {
                 // Initialize object.
                 if (properties.type === 'object') {
                     if (properties.default !== undefined) {
-                        writeValue.call(_this[_privateKey]._this, _.isFunction(properties.default) ? properties.default.call(_this) : properties.default, properties);
+                        writeValue.call(_this18[_privateKey]._this, _.isFunction(properties.default) ? properties.default.call(_this18) : properties.default, properties);
                     } else {
-                        writeValue.call(_this[_privateKey]._this, properties.objectType ? new properties.objectType({}, _this[_privateKey]._root) : {}, properties);
+                        writeValue.call(_this18[_privateKey]._this, properties.objectType ? new properties.objectType({}, _this18[_privateKey]._root) : {}, properties);
                     }
 
                     // Native arrays are not used so that Array class can be extended with custom behaviors.
                 } else if (properties.type === 'array') {
-                    writeValue.call(_this[_privateKey]._this, new SchemaArray(_this, properties), properties);
+                    writeValue.call(_this18[_privateKey]._this, new SchemaArray(_this18, properties), properties);
                 }
             }
 
             try {
-                return getter.call(_this, _this[_privateKey]._obj[indexOrAliasIndex], properties);
+                return getter.call(_this18, _this18[_privateKey]._obj[indexOrAliasIndex], properties);
             } catch (error) {
                 // This typically happens when the default value isn't valid -- log error.
-                _this[_privateKey]._errors.push(error);
+                _this18[_privateKey]._errors.push(error);
             }
         });
     }
 
     // Defines setter for specific field.
     function defineSetter(index, properties) {
-        var _this2 = this;
+        var _this19 = this;
 
         this.__defineSetter__(index, function (value) {
             // Don't proceed if readOnly is true.
@@ -506,10 +828,10 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
             try {
                 // this[_privateKey]._this[index] is used instead of this[_privateKey]._obj[index] to route through the public interface.
-                writeValue.call(_this2[_privateKey]._this, typecast.call(_this2, value, _this2[_privateKey]._this[index], properties), properties);
+                writeValue.call(_this19[_privateKey]._this, typecast.call(_this19, value, _this19[_privateKey]._this[index], properties), properties);
             } catch (error) {
                 // Setter failed to validate value -- log error.
-                _this2[_privateKey]._errors.push(error);
+                _this19[_privateKey]._errors.push(error);
             }
         });
     }
@@ -545,9 +867,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, SchemaArray);
 
             // Store all internals.
-            var _this3 = _possibleConstructorReturn(this, (SchemaArray.__proto__ || Object.getPrototypeOf(SchemaArray)).call(this));
+            var _this20 = _possibleConstructorReturn(this, (SchemaArray.__proto__ || Object.getPrototypeOf(SchemaArray)).call(this));
 
-            var _private = _this3[_privateKey] = {};
+            var _private = _this20[_privateKey] = {};
 
             // Store reference to self.
             _private._self = self;
@@ -559,13 +881,13 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             if (properties.arrayType) {
                 properties.arrayType = normalizeProperties.call(self, properties.arrayType);
             }
-            return _this3;
+            return _this20;
         }
 
         _createClass(SchemaArray, [{
             key: 'push',
             value: function push() {
-                var _this4 = this;
+                var _this21 = this;
 
                 // Values are passed through the typecast before being allowed onto the array if arrayType is set.
                 // In the case of rejection, the typecast returns undefined, which is not appended to the array.
@@ -577,7 +899,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 if (this[_privateKey]._properties.arrayType) {
                     values = [].map.call(args, function (value) {
-                        return typecast.call(_this4[_privateKey]._self, value, undefined, _this4[_privateKey]._properties.arrayType);
+                        return typecast.call(_this21[_privateKey]._self, value, undefined, _this21[_privateKey]._properties.arrayType);
                     }, this);
                 } else {
                     values = args;
@@ -586,7 +908,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                 // Enforce filter.
                 if (this[_privateKey]._properties.filter) {
                     values = _.filter(values, function (value) {
-                        return _this4[_privateKey]._properties.filter.call(_this4, value);
+                        return _this21[_privateKey]._properties.filter.call(_this21, value);
                     });
                 }
 
@@ -700,7 +1022,12 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             inheritRootThis: false,
 
             // If this is set to false, require will not allow falsy values such as empty strings
-            allowFalsyValues: true
+            allowFalsyValues: true,
+
+            // This defines the digit group separator used for parsing numbers, it defaults to ','
+            // For example 3,043,2013.01
+            numberGroupSeparator: ','
+
         }, options);
 
         // Some of the options require reflection.
@@ -744,7 +1071,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                 };
 
                 // Call custom constructor.
-                method.apply(obj, arguments);;
+                method.apply(obj, arguments);
 
                 // Cleanup and return SO.
                 delete obj[_privateKey]._reservedFields.super;
@@ -797,11 +1124,11 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                                         // Extend method by creating a binding that takes the `this` context given and adds `self`.
                                         // `self` is a reference to the original method, also bound to the correct `this`.
                                         mergedOptions[methodHome][name] = function () {
-                                            var _this5 = this,
+                                            var _this22 = this,
                                                 _arguments = arguments;
 
                                             this[_privateKey]._reservedFields.super = function () {
-                                                return method.apply(_this5, _arguments);
+                                                return method.apply(_this22, _arguments);
                                             };
                                             var ret = extendOptions[methodHome][name].apply(this, arguments);
                                             delete this[_privateKey]._reservedFields.super;
@@ -838,7 +1165,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             }]);
 
             function SchemaObjectInstance(values, _root) {
-                var _this6 = this;
+                var _this23 = this;
 
                 _classCallCheck(this, SchemaObjectInstance);
 
@@ -872,7 +1199,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // Normalize schema properties to allow for shorthand declarations.
                 _.each(schema, function (properties, index) {
-                    schema[index] = normalizeProperties.call(_this6, properties, index);
+                    schema[index] = normalizeProperties.call(_this23, properties, index);
                 });
 
                 // Define getters/typecasts based off of schema.
@@ -889,12 +1216,12 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                     var proxy = this[_privateKey]._this = new Proxy(this, {
                         // Ensure only public keys are shown.
                         ownKeys: function ownKeys(target) {
-                            return Object.keys(_this6.toObject());
+                            return Object.keys(_this23.toObject());
                         },
 
                         // Return keys to iterate.
                         enumerate: function enumerate(target) {
-                            return Object.keys(_this6[_privateKey]._this)[Symbol.iterator]();
+                            return Object.keys(_this23[_privateKey]._this)[Symbol.iterator]();
                         },
 
                         // Check to see if key exists.
@@ -921,28 +1248,28 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                         get: function get(target, name, receiver) {
                             // First check to see if it's a reserved field.
                             if (_reservedFields.includes(name)) {
-                                return _this6[_privateKey]._reservedFields[name];
+                                return _this23[_privateKey]._reservedFields[name];
                             }
 
                             // Support dot notation via lodash.
                             if (options.dotNotation && name.indexOf('.') !== -1) {
-                                return _.get(_this6[_privateKey]._this, name);
+                                return _.get(_this23[_privateKey]._this, name);
                             }
 
                             // Use registered getter without hitting the proxy to avoid creating an infinite loop.
-                            return _this6[name];
+                            return _this23[name];
                         },
 
                         // Intercept all set calls.
                         set: function set(target, name, value, receiver) {
                             // Support dot notation via lodash.
                             if (options.dotNotation && name.indexOf('.') !== -1) {
-                                return _.set(_this6[_privateKey]._this, name, value);
+                                return _.set(_this23[_privateKey]._this, name, value);
                             }
 
                             // Find real keyname if case sensitivity is off.
                             if (options.keysIgnoreCase && !schema[name]) {
-                                name = getIndex.call(_this6, name);
+                                name = getIndex.call(_this23, name);
                             }
 
                             if (!schema[name]) {
@@ -953,14 +1280,14 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                                 } else {
                                     // Add index to schema dynamically when value is set.
                                     // This is necessary for toObject to see the field.
-                                    addToSchema.call(_this6, name, {
+                                    addToSchema.call(_this23, name, {
                                         type: 'any'
                                     });
                                 }
                             }
 
                             // This hits the registered setter but bypasses the proxy to avoid an infinite loop.
-                            _this6[name] = value;
+                            _this23[name] = value;
 
                             // Necessary for Node v6.0. Prevents error: 'set' on proxy: trap returned falsish for property 'string'".
                             return true;
@@ -968,7 +1295,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                         // Intercept all delete calls.
                         deleteProperty: function deleteProperty(target, property) {
-                            _this6[property] = undefined;
+                            _this23[property] = undefined;
                             return true;
                         }
                     });
@@ -980,7 +1307,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                         // Temporarily ensure readOnly is turned off to prevent the set from failing.
                         var readOnly = properties.readOnly;
                         properties.readOnly = false;
-                        _this6[index] = _.isFunction(properties.default) ? properties.default.call(_this6) : properties.default;
+                        _this23[index] = _.isFunction(properties.default) ? properties.default.call(_this23) : properties.default;
                         properties.readOnly = readOnly;
                     }
                 });
@@ -1016,7 +1343,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             }, {
                 key: 'toObject',
                 value: function toObject() {
-                    var _this7 = this;
+                    var _this24 = this;
 
                     var options = this[_privateKey]._options;
                     var getObj = {};
@@ -1029,7 +1356,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                         }
 
                         // Fetch value through the public interface.
-                        var value = _this7[_privateKey]._this[index];
+                        var value = _this24[_privateKey]._this[index];
 
                         // Do not write undefined values to the object because of strange behavior when using with MongoDB.
                         // MongoDB will convert undefined to null and overwrite existing values in that field.
@@ -1085,10 +1412,10 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             }, {
                 key: 'clear',
                 value: function clear() {
-                    var _this8 = this;
+                    var _this25 = this;
 
                     _.each(this[_privateKey]._schema, function (properties, index) {
-                        clearField.call(_this8[_privateKey]._this, index, properties);
+                        clearField.call(_this25[_privateKey]._this, index, properties);
                     });
                 }
 
@@ -1097,7 +1424,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             }, {
                 key: 'getErrors',
                 value: function getErrors() {
-                    var _this9 = this;
+                    var _this26 = this;
 
                     var errors = [];
                     var _iteratorNormalCompletion2 = true;
@@ -1141,17 +1468,17 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                             return;
                         }
                         //Skip if required is a function, but returns false
-                        else if (typeof required === 'function' && !required.call(_this9)) {
+                        else if (typeof required === 'function' && !required.call(_this26)) {
                                 return;
                             }
 
                         //Skip if property has a value, is a boolean set to false, or if it's falsy and falsy values are allowed
-                        if (_this9[index] || typeof _this9[index] === 'boolean' || _this9[_privateKey]._options.allowFalsyValues && _this9[index] !== undefined) {
+                        if (_this26[index] || typeof _this26[index] === 'boolean' || _this26[_privateKey]._options.allowFalsyValues && _this26[index] !== undefined) {
                             return;
                         }
 
-                        var error = new SetterError(message, _this9[index], _this9[index], properties);
-                        error.schemaObject = _this9;
+                        var error = new SetterError(message, _this26[index], _this26[index], properties);
+                        error.schemaObject = _this26;
                         errors.push(error);
                     });
 

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -537,6 +537,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             if (_.isArray(properties[key])) {
                 customError = properties[key][1];
                 properties[key] = properties[key][0];
+            } else if (_typeof(properties[key]) === 'object' && properties[key].errorMessage && properties[key].value) {
+                customError = properties[key].errorMessage;
+                properties[key] = properties[key].value;
             } else {
                 customError = undefined;
             }
@@ -574,6 +577,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                 if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
                     customError = properties.enum[1];
                     properties.enum = properties.enum[0];
+                } else if (_typeof(properties.enum) === 'object' && properties.enum.errorMessage && properties.enum.value) {
+                    customError = properties.enum.errorMessage;
+                    properties.enum = properties.enum.value;
                 }
 
                 // If enum is being used, be sure the value is within definition.

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -126,15 +126,33 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     }
 
     // Represents an error encountered when trying to set a value.
+    // Code 1xxx
 
-    var SetterError = function SetterError(errorMessage, setValue, originalValue, fieldSchema) {
-        _classCallCheck(this, SetterError);
+    var SetterError = function () {
+        function SetterError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, SetterError);
 
-        this.errorMessage = errorMessage;
-        this.setValue = setValue;
-        this.originalValue = originalValue;
-        this.fieldSchema = fieldSchema;
-    };
+            this.errorMessage = errorMessage;
+            this.setValue = setValue;
+            this.originalValue = originalValue;
+            this.fieldSchema = fieldSchema;
+            this.errorCode = this.constructor.errorCode();
+        }
+
+        _createClass(SetterError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1000;
+            }
+        }]);
+
+        return SetterError;
+    }();
+
+    // Cast Error Base
+    // Thrown when a value cannot be cast to the type specified by the schema
+    // Code 11xx
+
 
     var CastError = function (_SetterError) {
         _inherits(CastError, _SetterError);
@@ -145,27 +163,17 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             var _this = _possibleConstructorReturn(this, (CastError.__proto__ || Object.getPrototypeOf(CastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
 
             _this.errorType = 'CastError';
-            _this.errorCode = 1000;
             return _this;
         }
 
+        _createClass(CastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1100;
+            }
+        }]);
+
         return CastError;
-    }(SetterError);
-
-    var ValidationError = function (_SetterError2) {
-        _inherits(ValidationError, _SetterError2);
-
-        function ValidationError(errorMessage, setValue, originalValue, fieldSchema) {
-            _classCallCheck(this, ValidationError);
-
-            var _this2 = _possibleConstructorReturn(this, (ValidationError.__proto__ || Object.getPrototypeOf(ValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this2.errorType = 'ValidationError';
-            _this2.errorCode = 2000;
-            return _this2;
-        }
-
-        return ValidationError;
     }(SetterError);
 
     var StringCastError = function (_CastError) {
@@ -175,12 +183,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, StringCastError);
 
             var errorMessage = 'String type cannot typecast Object or Array types.';
-
-            var _this3 = _possibleConstructorReturn(this, (StringCastError.__proto__ || Object.getPrototypeOf(StringCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this3.errorCode = 1001;
-            return _this3;
+            return _possibleConstructorReturn(this, (StringCastError.__proto__ || Object.getPrototypeOf(StringCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringCastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1101;
+            }
+        }]);
 
         return StringCastError;
     }(CastError);
@@ -192,12 +203,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, NumberCastError);
 
             var errorMessage = 'Number could not be typecast from the provided ' + sourceType;
-
-            var _this4 = _possibleConstructorReturn(this, (NumberCastError.__proto__ || Object.getPrototypeOf(NumberCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this4.errorCode = 1002;
-            return _this4;
+            return _possibleConstructorReturn(this, (NumberCastError.__proto__ || Object.getPrototypeOf(NumberCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(NumberCastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1102;
+            }
+        }]);
 
         return NumberCastError;
     }(CastError);
@@ -209,12 +223,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, ArrayCastError);
 
             var errorMessage = 'Array type cannot typecast non-Array types.';
-
-            var _this5 = _possibleConstructorReturn(this, (ArrayCastError.__proto__ || Object.getPrototypeOf(ArrayCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this5.errorCode = 1003;
-            return _this5;
+            return _possibleConstructorReturn(this, (ArrayCastError.__proto__ || Object.getPrototypeOf(ArrayCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(ArrayCastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1103;
+            }
+        }]);
 
         return ArrayCastError;
     }(CastError);
@@ -226,12 +243,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, ObjectCastError);
 
             var errorMessage = 'Object type cannot typecast non-Object types.';
-
-            var _this6 = _possibleConstructorReturn(this, (ObjectCastError.__proto__ || Object.getPrototypeOf(ObjectCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this6.errorCode = 1004;
-            return _this6;
+            return _possibleConstructorReturn(this, (ObjectCastError.__proto__ || Object.getPrototypeOf(ObjectCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(ObjectCastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1104;
+            }
+        }]);
 
         return ObjectCastError;
     }(CastError);
@@ -243,15 +263,50 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, DateCastError);
 
             var errorMessage = 'Date type cannot typecast Array or Object types.';
-
-            var _this7 = _possibleConstructorReturn(this, (DateCastError.__proto__ || Object.getPrototypeOf(DateCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this7.errorCode = 1005;
-            return _this7;
+            return _possibleConstructorReturn(this, (DateCastError.__proto__ || Object.getPrototypeOf(DateCastError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(DateCastError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1105;
+            }
+        }]);
 
         return DateCastError;
     }(CastError);
+
+    // Validation error base
+    // Thrown when a value does not meet the validation criteria set by the schema
+    // Code 12xx
+
+
+    var ValidationError = function (_SetterError2) {
+        _inherits(ValidationError, _SetterError2);
+
+        function ValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, ValidationError);
+
+            var _this7 = _possibleConstructorReturn(this, (ValidationError.__proto__ || Object.getPrototypeOf(ValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+
+            _this7.errorType = 'ValidationError';
+            return _this7;
+        }
+
+        _createClass(ValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1200;
+            }
+        }]);
+
+        return ValidationError;
+    }(SetterError);
+
+    /**
+     * String Validation Errors
+     * Codes 121x
+     */
 
     var StringValidationError = function (_ValidationError) {
         _inherits(StringValidationError, _ValidationError);
@@ -259,43 +314,17 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
         function StringValidationError(errorMessage, setValue, originalValue, fieldSchema) {
             _classCallCheck(this, StringValidationError);
 
-            var _this8 = _possibleConstructorReturn(this, (StringValidationError.__proto__ || Object.getPrototypeOf(StringValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this8.errorCode = 2100;
-            return _this8;
+            return _possibleConstructorReturn(this, (StringValidationError.__proto__ || Object.getPrototypeOf(StringValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1210;
+            }
+        }]);
 
         return StringValidationError;
-    }(ValidationError);
-
-    var NumberValidationError = function (_ValidationError2) {
-        _inherits(NumberValidationError, _ValidationError2);
-
-        function NumberValidationError(errorMessage, setValue, originalValue, fieldSchema) {
-            _classCallCheck(this, NumberValidationError);
-
-            var _this9 = _possibleConstructorReturn(this, (NumberValidationError.__proto__ || Object.getPrototypeOf(NumberValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this9.errorCode = 2200;
-            return _this9;
-        }
-
-        return NumberValidationError;
-    }(ValidationError);
-
-    var DateValidationError = function (_ValidationError3) {
-        _inherits(DateValidationError, _ValidationError3);
-
-        function DateValidationError(errorMessage, setValue, originalValue, fieldSchema) {
-            _classCallCheck(this, DateValidationError);
-
-            var _this10 = _possibleConstructorReturn(this, (DateValidationError.__proto__ || Object.getPrototypeOf(DateValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this10.errorCode = 2300;
-            return _this10;
-        }
-
-        return DateValidationError;
     }(ValidationError);
 
     var StringEnumValidationError = function (_StringValidationErro) {
@@ -305,12 +334,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, StringEnumValidationError);
 
             errorMessage = errorMessage || 'String does not exist in enum list.';
-
-            var _this11 = _possibleConstructorReturn(this, (StringEnumValidationError.__proto__ || Object.getPrototypeOf(StringEnumValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this11.errorCode = 2101;
-            return _this11;
+            return _possibleConstructorReturn(this, (StringEnumValidationError.__proto__ || Object.getPrototypeOf(StringEnumValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringEnumValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1211;
+            }
+        }]);
 
         return StringEnumValidationError;
     }(StringValidationError);
@@ -322,12 +354,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, StringMinLengthValidationError);
 
             errorMessage = errorMessage || 'String length too short to meet minLength requirement.';
-
-            var _this12 = _possibleConstructorReturn(this, (StringMinLengthValidationError.__proto__ || Object.getPrototypeOf(StringMinLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this12.errorCode = 2102;
-            return _this12;
+            return _possibleConstructorReturn(this, (StringMinLengthValidationError.__proto__ || Object.getPrototypeOf(StringMinLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringMinLengthValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1212;
+            }
+        }]);
 
         return StringMinLengthValidationError;
     }(StringValidationError);
@@ -339,12 +374,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, StringMaxLengthValidationError);
 
             errorMessage = errorMessage || 'String length too long to meet maxLength requirement.';
-
-            var _this13 = _possibleConstructorReturn(this, (StringMaxLengthValidationError.__proto__ || Object.getPrototypeOf(StringMaxLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this13.errorCode = 2103;
-            return _this13;
+            return _possibleConstructorReturn(this, (StringMaxLengthValidationError.__proto__ || Object.getPrototypeOf(StringMaxLengthValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringMaxLengthValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1213;
+            }
+        }]);
 
         return StringMaxLengthValidationError;
     }(StringValidationError);
@@ -356,15 +394,42 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, StringRegexValidationError);
 
             errorMessage = errorMessage || 'String does not match regular expression pattern.';
-
-            var _this14 = _possibleConstructorReturn(this, (StringRegexValidationError.__proto__ || Object.getPrototypeOf(StringRegexValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this14.errorCode = 2104;
-            return _this14;
+            return _possibleConstructorReturn(this, (StringRegexValidationError.__proto__ || Object.getPrototypeOf(StringRegexValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(StringRegexValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1214;
+            }
+        }]);
 
         return StringRegexValidationError;
     }(StringValidationError);
+
+    /**
+     * Number Validation Errors
+     * Codes 122x
+     */
+
+    var NumberValidationError = function (_ValidationError2) {
+        _inherits(NumberValidationError, _ValidationError2);
+
+        function NumberValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, NumberValidationError);
+
+            return _possibleConstructorReturn(this, (NumberValidationError.__proto__ || Object.getPrototypeOf(NumberValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+        }
+
+        _createClass(NumberValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1220;
+            }
+        }]);
+
+        return NumberValidationError;
+    }(ValidationError);
 
     var NumberMinValidationError = function (_NumberValidationErro) {
         _inherits(NumberMinValidationError, _NumberValidationErro);
@@ -373,12 +438,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, NumberMinValidationError);
 
             errorMessage = errorMessage || 'Number is too small to meet min requirement.';
-
-            var _this15 = _possibleConstructorReturn(this, (NumberMinValidationError.__proto__ || Object.getPrototypeOf(NumberMinValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this15.errorCode = 2201;
-            return _this15;
+            return _possibleConstructorReturn(this, (NumberMinValidationError.__proto__ || Object.getPrototypeOf(NumberMinValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(NumberMinValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1221;
+            }
+        }]);
 
         return NumberMinValidationError;
     }(NumberValidationError);
@@ -390,15 +458,42 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, NumberMaxValidationError);
 
             errorMessage = errorMessage || 'Number is too big to meet max requirement.';
-
-            var _this16 = _possibleConstructorReturn(this, (NumberMaxValidationError.__proto__ || Object.getPrototypeOf(NumberMaxValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this16.errorCode = 2202;
-            return _this16;
+            return _possibleConstructorReturn(this, (NumberMaxValidationError.__proto__ || Object.getPrototypeOf(NumberMaxValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(NumberMaxValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1222;
+            }
+        }]);
 
         return NumberMaxValidationError;
     }(NumberValidationError);
+
+    /**
+     * Date Validation Errors
+     * Codes 123x
+     */
+
+    var DateValidationError = function (_ValidationError3) {
+        _inherits(DateValidationError, _ValidationError3);
+
+        function DateValidationError(errorMessage, setValue, originalValue, fieldSchema) {
+            _classCallCheck(this, DateValidationError);
+
+            return _possibleConstructorReturn(this, (DateValidationError.__proto__ || Object.getPrototypeOf(DateValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
+        }
+
+        _createClass(DateValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1230;
+            }
+        }]);
+
+        return DateValidationError;
+    }(ValidationError);
 
     var DateParseValidationError = function (_DateValidationError) {
         _inherits(DateParseValidationError, _DateValidationError);
@@ -407,12 +502,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             _classCallCheck(this, DateParseValidationError);
 
             errorMessage = errorMessage || 'Could not parse date.';
-
-            var _this17 = _possibleConstructorReturn(this, (DateParseValidationError.__proto__ || Object.getPrototypeOf(DateParseValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
-
-            _this17.errorCode = 2301;
-            return _this17;
+            return _possibleConstructorReturn(this, (DateParseValidationError.__proto__ || Object.getPrototypeOf(DateParseValidationError)).call(this, errorMessage, setValue, originalValue, fieldSchema));
         }
+
+        _createClass(DateParseValidationError, null, [{
+            key: 'errorCode',
+            value: function errorCode() {
+                return 1231;
+            }
+        }]);
 
         return DateParseValidationError;
     }(DateValidationError);
@@ -520,9 +618,17 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                     value = value ? 1 : 0;
                 }
 
-                // Remove comma from strings.
+                // Remove/convert number group separators
                 if (typeof value === 'string') {
-                    value = value.replace(new RegExp(options.numberGroupSeparator, 'g'), '');
+                    if (options.useDecimalNumberGroupSeparator) {
+                        // Remove decimals
+                        value = value.replace(/\./g, '');
+                        // Replace commas with decimals for js parsing
+                        value = value.replace(/,/g, '.');
+                    } else {
+                        //Remove commas
+                        value = value.replace(/,/g, '');
+                    }
 
                     // Reject if string was not a valid number
                     if (isNaN(Number(value))) {
@@ -1025,8 +1131,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             allowFalsyValues: true,
 
             // This defines the digit group separator used for parsing numbers, it defaults to ','
-            // For example 3,043,2013.01
-            numberGroupSeparator: ','
+            // For example 3,043,201.01. However if enabled it swaps commas and decimals to allow parsing
+            // numbers like 3.043.201,01
+            useDecimalNumberGroupSeparator: false
 
         }, options);
 

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -315,6 +315,10 @@
                 customError = properties[key][1];
                 properties[key] = properties[key][0];
             }
+            else if (typeof properties[key] === 'object' && properties[key].errorMessage && properties[key].value) {
+                customError = properties[key].errorMessage;
+                properties[key] = properties[key].value;
+            }
             else {
                 customError = undefined;
             }
@@ -353,6 +357,11 @@
                     customError = properties.enum[1];
                     properties.enum = properties.enum[0];
                 }
+                else if (typeof properties.enum === 'object' && properties.enum.errorMessage && properties.enum.value) {
+                    customError = properties.enum.errorMessage;
+                    properties.enum = properties.enum.value;
+                }
+
 
                 // If enum is being used, be sure the value is within definition.
                 if (_.isArray(properties.enum) && properties.enum.indexOf(value) === -1) {

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -99,9 +99,143 @@
         }
     }
 
+    class CastError extends SetterError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorType = 'CastError';
+            this.errorCode = 1000;
+        }
+    }
+
+    class ValidationError extends SetterError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorType = 'ValidationError';
+            this.errorCode = 2000;
+        }
+    }
+
+    class StringCastError extends CastError {
+        constructor(setValue, originalValue, fieldSchema) {
+            let errorMessage = 'String type cannot typecast Object or Array types.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 1001;
+        }
+    }
+
+    class NumberCastError extends CastError {
+        constructor(sourceType, setValue, originalValue, fieldSchema) {
+            let errorMessage = 'Number could not be typecast from the provided ' + sourceType;
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 1002;
+        }
+    }
+
+    class ArrayCastError extends CastError {
+        constructor(setValue, originalValue, fieldSchema) {
+            let errorMessage = 'Array type cannot typecast non-Array types.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 1003;
+        }
+    }
+
+    class ObjectCastError extends CastError {
+        constructor(setValue, originalValue, fieldSchema) {
+            let errorMessage = 'Object type cannot typecast non-Object types.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 1004;
+        }
+    }
+
+    class DateCastError extends CastError {
+        constructor(setValue, originalValue, fieldSchema) {
+            let errorMessage = 'Date type cannot typecast Array or Object types.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 1005;
+        }
+    }
+
+    class StringValidationError extends ValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2100;
+        }
+    }
+
+    class NumberValidationError extends ValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2200;
+        }
+    }
+
+    class DateValidationError extends ValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2300;
+        }
+    }
+
+    class StringEnumValidationError extends StringValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'String does not exist in enum list.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2101;
+        }
+    }
+
+    class StringMinLengthValidationError extends StringValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'String length too short to meet minLength requirement.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2102;
+        }
+    }
+
+    class StringMaxLengthValidationError extends StringValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'String length too long to meet maxLength requirement.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2103;
+        }
+    }
+
+    class StringRegexValidationError extends StringValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'String does not match regular expression pattern.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2104;
+        }
+    }
+
+    class NumberMinValidationError extends NumberValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'Number is too small to meet min requirement.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2201;
+        }
+    }
+
+    class NumberMaxValidationError extends NumberValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'Number is too big to meet max requirement.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2202;
+        }
+    }
+
+    class DateParseValidationError extends DateValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            errorMessage = errorMessage || 'Could not parse date.';
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorCode = 2301;
+        }
+    }
+
     // Returns typecasted value if possible. If rejected, originalValue is returned.
     function typecast(value, originalValue, properties) {
         const options = this[_privateKey]._options;
+        let customError;
 
         // Allow transform to manipulate raw properties.
         if (properties.transform) {
@@ -113,12 +247,23 @@
             return null;
         }
 
+        // Helper function designed to detect and handle usage of array-form custom error messages for validators
+        function detectCustomErrorMessage(key) {
+            if (_.isArray(properties[key])) {
+                customError = properties[key][1];
+                properties[key] = properties[key][0];
+            }
+            else {
+                customError = undefined;
+            }
+        }
+
         // Property types are always normalized as lowercase strings despite shorthand definitions being available.
         switch (properties.type) {
             case 'string':
                 // Reject if object or array.
                 if (_.isObject(value) || _.isArray(value)) {
-                    throw new SetterError('String type cannot typecast Object or Array types.', value, originalValue, properties);
+                    throw new StringCastError(value, originalValue, properties);
                 }
 
                 // If index is being set with null or undefined, set value and end.
@@ -141,24 +286,39 @@
                     value = value.substr(0, properties.maxLength);
                 }
 
+                // Detect custom error message usage for enum (can't use function here as enum is expected to be an array)
+                if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
+                    customError = properties.enum[1];
+                    properties.enum = properties.enum[0];
+                }
+
                 // If enum is being used, be sure the value is within definition.
                 if (_.isArray(properties.enum) && properties.enum.indexOf(value) === -1) {
-                    throw new SetterError('String does not exist in enum list.', value, originalValue, properties);
+                    throw new StringEnumValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for minLength
+                detectCustomErrorMessage('minLength');
 
                 // If minLength is defined, check to be sure the string is > minLength.
                 if (properties.minLength !== undefined && value.length < properties.minLength) {
-                    throw new SetterError('String length too short to meet minLength requirement.', value, originalValue, properties);
+                    throw new StringMinLengthValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for maxLength
+                detectCustomErrorMessage('maxLength');
 
                 // If maxLength is defined, check to be sure the string is < maxLength.
                 if (properties.maxLength !== undefined && value.length > properties.maxLength) {
-                    throw new SetterError('String length too long to meet maxLength requirement.', value, originalValue, properties);
+                    throw new StringMaxLengthValidationError(customError, value, originalValue, properties);
                 }
+
+                // Detect custom error message usage for maxLength
+                detectCustomErrorMessage('regex');
 
                 // If regex is defined, check to be sure the string matches the regex pattern.
                 if (properties.regex && !properties.regex.test(value)) {
-                    throw new SetterError('String does not match regular expression pattern.', value, originalValue, properties);
+                    throw new StringRegexValidationError(customError, value, originalValue, properties);
                 }
 
                 return value;
@@ -176,28 +336,45 @@
 
                 // Remove comma from strings.
                 if (typeof value === 'string') {
-                    value = value.replace(/,/g, '');
+                    value = value.replace(new RegExp(options.numberGroupSeparator, 'g'), '');
+
+                    // Reject if string was not a valid number
+                    if (isNaN(Number(value))) {
+                      throw new NumberCastError('String', value, originalValue, properties);
+                    }
                 }
 
                 // Reject if array, object, or not numeric.
-                if (_.isArray(value) || _.isObject(value) || !isNumeric(value)) {
-                    throw new SetterError('Number type cannot typecast Array or Object types.', value, originalValue, properties);
+                if (_.isArray(value)) {
+                    throw new NumberCastError('Array', value, originalValue, properties);
+                }
+                else if (_.isObject(value)) {
+                    throw new NumberCastError('Object', value, originalValue, properties);
+                }
+                else if (!isNumeric(value)) {
+                    throw new NumberCastError('Non-numeric', value, originalValue, properties);
                 }
 
                 // Typecast to number.
-                value = value * 1;
+                value = Number(value);
 
                 // Transformation after typecasting but before validation and filters.
                 if (properties.numberTransform) {
                     value = properties.numberTransform.call(this[_privateKey]._root, value, originalValue, properties);
                 }
 
+                // Detect custom error message usage for min
+                detectCustomErrorMessage('min');
+
                 if (properties.min !== undefined && value < properties.min) {
-                    throw new SetterError('Number is too small to meet min requirement.', value, originalValue, properties);
+                    throw new NumberMinValidationError(customError, value, originalValue, properties);
                 }
 
+                // Detect custom error message usage for min
+                detectCustomErrorMessage('max');
+
                 if (properties.max !== undefined && value > properties.max) {
-                    throw new SetterError('Number is too big to meet max requirement.', value, originalValue, properties);
+                    throw new NumberMaxValidationError(customError, value, originalValue, properties);
                 }
 
                 return value;
@@ -215,11 +392,11 @@
 
                 // If is Number, <0 is true and >0 is false.
                 if (isNumeric(value)) {
-                    return (value * 1) > 0 ? true : false;
+                    return (value * 1) > 0;
                 }
 
                 // Use Javascript to eval and return boolean.
-                value = value ? true : false;
+                value = !!value;
 
                 // Transformation after typecasting but before validation and filters.
                 if (properties.booleanTransform) {
@@ -236,7 +413,7 @@
 
                 // Reject if not array.
                 if (!_.isArray(value)) {
-                    throw new SetterError('Array type cannot typecast non-Array types.', value, originalValue, properties);
+                    throw new ArrayCastError(value, originalValue, properties);
                 }
 
                 // Arrays are never set directly.
@@ -252,7 +429,7 @@
             case 'object':
                 // If it's not an Object, reject.
                 if (!_.isObject(value)) {
-                    throw new SetterError('Object type cannot typecast non-Object types.', value, originalValue, properties);
+                    throw new ObjectCastError(value, originalValue, properties);
                 }
 
                 // If object is schema object and an entirely new object was passed, clear values and set.
@@ -289,7 +466,7 @@
 
                 // Reject if object, array or boolean.
                 if (!_.isDate(value) && !_.isString(value) && !_.isNumber(value)) {
-                    throw new SetterError('Date type cannot typecast Array or Object types.', value, originalValue, properties);
+                    throw new DateCastError(value, originalValue, properties);
                 }
 
                 // Attempt to parse string value with Date.parse (which returns number of milliseconds).
@@ -304,7 +481,7 @@
 
                 // If the date couldn't be parsed, do not modify index.
                 if (value == 'Invalid Date' || !_.isDate(value)) {
-                    throw new SetterError('Could not parse date.', value, originalValue, properties);
+                    throw new DateParseValidationError(customError, value, originalValue, properties);
                 }
 
                 // Transformation after typecasting but before validation and filters.
@@ -626,7 +803,12 @@
                 inheritRootThis: false,
 
                 // If this is set to false, require will not allow falsy values such as empty strings
-                allowFalsyValues: true
+                allowFalsyValues: true,
+
+                // This defines the digit group separator used for parsing numbers, it defaults to ','
+                // For example 3,043,2013.01
+                numberGroupSeparator: ','
+
             }, options);
 
             // Some of the options require reflection.
@@ -670,7 +852,7 @@
                     };
 
                     // Call custom constructor.
-                    method.apply(obj, arguments);;
+                    method.apply(obj, arguments);
 
                     // Cleanup and return SO.
                     delete obj[_privateKey]._reservedFields.super;

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -90,28 +90,31 @@
     }
 
     // Represents an error encountered when trying to set a value.
+    // Code 1xxx
     class SetterError {
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             this.errorMessage = errorMessage;
             this.setValue = setValue;
             this.originalValue = originalValue;
             this.fieldSchema = fieldSchema;
+            this.errorCode = this.constructor.errorCode();
+        }
+
+        static errorCode() {
+            return 1000;
         }
     }
 
+    // Cast Error Base
+    // Thrown when a value cannot be cast to the type specified by the schema
+    // Code 11xx
     class CastError extends SetterError {
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             super(errorMessage, setValue, originalValue, fieldSchema);
             this.errorType = 'CastError';
-            this.errorCode = 1000;
         }
-    }
-
-    class ValidationError extends SetterError {
-        constructor(errorMessage, setValue, originalValue, fieldSchema) {
-            super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorType = 'ValidationError';
-            this.errorCode = 2000;
+        static errorCode() {
+            return 1100;
         }
     }
 
@@ -119,7 +122,9 @@
         constructor(setValue, originalValue, fieldSchema) {
             let errorMessage = 'String type cannot typecast Object or Array types.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 1001;
+        }
+        static errorCode() {
+            return 1101;
         }
     }
 
@@ -127,7 +132,9 @@
         constructor(sourceType, setValue, originalValue, fieldSchema) {
             let errorMessage = 'Number could not be typecast from the provided ' + sourceType;
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 1002;
+        }
+        static errorCode() {
+            return 1102;
         }
     }
 
@@ -135,7 +142,9 @@
         constructor(setValue, originalValue, fieldSchema) {
             let errorMessage = 'Array type cannot typecast non-Array types.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 1003;
+        }
+        static errorCode() {
+            return 1103;
         }
     }
 
@@ -143,7 +152,9 @@
         constructor(setValue, originalValue, fieldSchema) {
             let errorMessage = 'Object type cannot typecast non-Object types.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 1004;
+        }
+        static errorCode() {
+            return 1104;
         }
     }
 
@@ -151,28 +162,36 @@
         constructor(setValue, originalValue, fieldSchema) {
             let errorMessage = 'Date type cannot typecast Array or Object types.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 1005;
+        }
+        static errorCode() {
+            return 1105;
         }
     }
+
+    // Validation error base
+    // Thrown when a value does not meet the validation criteria set by the schema
+    // Code 12xx
+    class ValidationError extends SetterError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+            this.errorType = 'ValidationError';
+        }
+        static errorCode() {
+            return 1200;
+        }
+    }
+
+    /**
+     * String Validation Errors
+     * Codes 121x
+     */
 
     class StringValidationError extends ValidationError {
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2100;
         }
-    }
-
-    class NumberValidationError extends ValidationError {
-        constructor(errorMessage, setValue, originalValue, fieldSchema) {
-            super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2200;
-        }
-    }
-
-    class DateValidationError extends ValidationError {
-        constructor(errorMessage, setValue, originalValue, fieldSchema) {
-            super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2300;
+        static errorCode() {
+            return 1210;
         }
     }
 
@@ -180,7 +199,9 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'String does not exist in enum list.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2101;
+        }
+        static errorCode() {
+            return 1211;
         }
     }
 
@@ -188,7 +209,9 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'String length too short to meet minLength requirement.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2102;
+        }
+        static errorCode() {
+            return 1212;
         }
     }
 
@@ -196,7 +219,9 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'String length too long to meet maxLength requirement.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2103;
+        }
+        static errorCode() {
+            return 1213;
         }
     }
 
@@ -204,7 +229,23 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'String does not match regular expression pattern.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2104;
+        }
+        static errorCode() {
+            return 1214;
+        }
+    }
+
+    /**
+     * Number Validation Errors
+     * Codes 122x
+     */
+
+    class NumberValidationError extends ValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+        }
+        static errorCode() {
+            return 1220;
         }
     }
 
@@ -212,7 +253,9 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'Number is too small to meet min requirement.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2201;
+        }
+        static errorCode() {
+            return 1221;
         }
     }
 
@@ -220,7 +263,23 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'Number is too big to meet max requirement.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2202;
+        }
+        static errorCode() {
+            return 1222;
+        }
+    }
+
+    /**
+     * Date Validation Errors
+     * Codes 123x
+     */
+
+    class DateValidationError extends ValidationError {
+        constructor(errorMessage, setValue, originalValue, fieldSchema) {
+            super(errorMessage, setValue, originalValue, fieldSchema);
+        }
+        static errorCode() {
+            return 1230;
         }
     }
 
@@ -228,9 +287,12 @@
         constructor(errorMessage, setValue, originalValue, fieldSchema) {
             errorMessage = errorMessage || 'Could not parse date.';
             super(errorMessage, setValue, originalValue, fieldSchema);
-            this.errorCode = 2301;
+        }
+        static errorCode() {
+            return 1231;
         }
     }
+
 
     // Returns typecasted value if possible. If rejected, originalValue is returned.
     function typecast(value, originalValue, properties) {
@@ -334,9 +396,18 @@
                     value = value ? 1 : 0;
                 }
 
-                // Remove comma from strings.
+                // Remove/convert number group separators
                 if (typeof value === 'string') {
-                    value = value.replace(new RegExp(options.numberGroupSeparator, 'g'), '');
+                    if (options.useDecimalNumberGroupSeparator) {
+                        // Remove decimals
+                        value = value.replace(/\./g, '');
+                        // Replace commas with decimals for js parsing
+                        value = value.replace(/,/g, '.');
+                    }
+                    else {
+                        //Remove commas
+                        value = value.replace(/,/g, '');
+                    }
 
                     // Reject if string was not a valid number
                     if (isNaN(Number(value))) {
@@ -806,8 +877,9 @@
                 allowFalsyValues: true,
 
                 // This defines the digit group separator used for parsing numbers, it defaults to ','
-                // For example 3,043,2013.01
-                numberGroupSeparator: ','
+                // For example 3,043,201.01. However if enabled it swaps commas and decimals to allow parsing
+                // numbers like 3.043.201,01
+                useDecimalNumberGroupSeparator: false
 
             }, options);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -869,12 +869,43 @@ describe('String', function () {
             o.string.should.equal('ABCD');
         });
 
-        it('should handle custom errors', function () {
+        it('should handle custom errors in array format', function () {
             var SO = new SchemaObject({
                 string: {
                     type: String,
                     regex: [new RegExp('^([A-Z]{4})$'), 'This can only contain capital letters A-Z, and must be 4' +
                         ' characters long']
+                }
+            });
+
+            var o = new SO();
+
+            o.string = 'abcd';
+            should.not.exist(o.string);
+
+            var errors = o.getErrors();
+            should.exist(errors);
+            errors.length.should.equal(1);
+            errors[0].errorMessage.should.equal('This can only contain capital letters A-Z, and must be 4 characters' +
+                ' long');
+            errors[0].errorCode.should.equal(1214);
+            errors[0].errorType.should.equal('ValidationError');
+
+            o.string = 'ABCD';
+            o.string.should.equal('ABCD');
+
+            o.string = '1234';
+            o.string.should.equal('ABCD');
+        });
+
+        it('should handle custom errors in object format', function () {
+            var SO = new SchemaObject({
+                string: {
+                    type: String,
+                    regex: {
+                        value: new RegExp('^([A-Z]{4})$'),
+                        errorMessage: 'This can only contain capital letters A-Z, and must be 4 characters long'
+                    }
                 }
             });
 
@@ -949,7 +980,7 @@ describe('String', function () {
             o.string.should.equal('allowed');
         });
 
-        it('should handle custom error', function () {
+        it('should handle custom error in array format', function () {
             var SO = new SchemaObject({
                 string: {
                     type: String,
@@ -957,6 +988,29 @@ describe('String', function () {
                         ['a', 'b'],
                         'Must be a or b'
                     ]
+                }
+            });
+            var o = new SO({
+                string: 'c'
+            });
+
+            should.not.exist(o.string);
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+            errors[0].errorMessage.should.equal('Must be a or b');
+            errors[0].errorCode.should.equal(1211);
+
+            o.isErrors().should.equal(true);
+        });
+
+        it('should handle custom error in object format', function () {
+            var SO = new SchemaObject({
+                string: {
+                    type: String,
+                    enum: {
+                        value: ['a', 'b'],
+                        errorMessage: 'Must be a or b'
+                    }
                 }
             });
             var o = new SO({
@@ -1046,11 +1100,33 @@ describe('String', function () {
             o.notEmptyString.should.equal('1');
         });
 
-        it('should allow custom error message', function () {
+        it('should allow custom error message in array format', function () {
             var SO = new SchemaObject({
                 notEmptyString: {
                     type: String,
                     minLength: [1, 'notEmptyString cannot be empty']
+                }
+            });
+
+            var o = new SO();
+            o.notEmptyString = '';
+            should.not.exist(o.notEmptyString);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+            errors[0].errorMessage.should.equal('notEmptyString cannot be empty');
+            errors[0].errorType.should.equal('ValidationError');
+            errors[0].errorCode.should.equal(1212);
+        });
+
+        it('should allow custom error message in object format', function () {
+            var SO = new SchemaObject({
+                notEmptyString: {
+                    type: String,
+                    minLength: {
+                        value: 1,
+                        errorMessage: 'notEmptyString cannot be empty'
+                    }
                 }
             });
 
@@ -1082,11 +1158,33 @@ describe('String', function () {
             o.shortString.should.equal('1');
         });
 
-        it('should allow custom error message', function () {
+        it('should allow custom error message in array format', function () {
             var SO = new SchemaObject({
                 shortString: {
                     type: String,
                     maxLength: [5, 'shortString cannot be longer than 5 characters']
+                }
+            });
+
+            var o = new SO();
+            o.shortString = '123456';
+            should.not.exist(o.shortString);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+            errors[0].errorMessage.should.equal('shortString cannot be longer than 5 characters');
+            errors[0].errorType.should.equal('ValidationError');
+            errors[0].errorCode.should.equal(1213);
+        });
+
+        it('should allow custom error message in object format', function () {
+            var SO = new SchemaObject({
+                shortString: {
+                    type: String,
+                    maxLength: {
+                        value: 5,
+                        errorMessage: 'shortString cannot be longer than 5 characters'
+                    }
                 }
             });
 
@@ -1175,7 +1273,7 @@ describe('Number', function () {
         });
 
         it('should typecast string with period digit group separator to number if option enabled', function () {
-            SO = new SchemaObject({
+            var SO = new SchemaObject({
                 number: Number,
                 minMax: {
                     type: Number,
@@ -1238,6 +1336,67 @@ describe('Number', function () {
             o.minMax = 150;
             o.minMax.should.equal(150);
         });
+
+        it('should handle custom errors in array format', function () {
+            var SO = new SchemaObject({
+                number: Number,
+                minMax: {
+                    type: Number,
+                    min: [100, 'min is 100'],
+                    max: 200
+                }
+            });
+            var o = new SO();
+
+            o.minMax = 0;
+            should.not.exist(o.minMax);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+
+            o.isErrors().should.equal(true);
+
+            errors[0].errorMessage.should.equal('min is 100');
+            errors[0].errorCode.should.equal(1221);
+
+            o.minMax = 100;
+            o.minMax.should.equal(100);
+
+            o.minMax = 150;
+            o.minMax.should.equal(150);
+        });
+
+        it('should handle custom errors in object format', function () {
+            var SO = new SchemaObject({
+                number: Number,
+                minMax: {
+                    type: Number,
+                    min: {
+                        value:100,
+                        errorMessage:'min is 100'
+                    },
+                    max: 200
+                }
+            });
+            var o = new SO();
+
+            o.minMax = 0;
+            should.not.exist(o.minMax);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+
+            o.isErrors().should.equal(true);
+
+            errors[0].errorMessage.should.equal('min is 100');
+            errors[0].errorCode.should.equal(1221);
+
+            o.minMax = 100;
+            o.minMax.should.equal(100);
+
+            o.minMax = 150;
+            o.minMax.should.equal(150);
+        });
     });
 
     describe('max', function () {
@@ -1251,6 +1410,55 @@ describe('Number', function () {
 
             o.minMax = 200;
             o.minMax.should.equal(200);
+        });
+
+        it('should handle custom errors in array format', function () {
+            var SO = new SchemaObject({
+                number: Number,
+                minMax: {
+                    type: Number,
+                    min: 100,
+                    max: [200, 'max is 200']
+                }
+            });
+            var o = new SO();
+
+            o.minMax = 300;
+            should.not.exist(o.minMax);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+
+            o.isErrors().should.equal(true);
+
+            errors[0].errorMessage.should.equal('max is 200');
+            errors[0].errorCode.should.equal(1222);
+        });
+
+        it('should handle custom errors in object format', function () {
+            var SO = new SchemaObject({
+                number: Number,
+                minMax: {
+                    type: Number,
+                    min: 100,
+                    max: {
+                        value: 200,
+                        errorMessage:'max is 200'
+                    }
+                }
+            });
+            var o = new SO();
+
+            o.minMax = 300;
+            should.not.exist(o.minMax);
+
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+
+            o.isErrors().should.equal(true);
+
+            errors[0].errorMessage.should.equal('max is 200');
+            errors[0].errorCode.should.equal(1222);
         });
     });
 
@@ -1302,6 +1510,87 @@ describe('Number', function () {
             }
         });
 
+        var SOO = new SchemaObject({
+            number: {
+                type: Number,
+                min: {
+                    value: 5,
+                    errorMessage: 'number cannot be smaller than 5'
+                },
+                max: {
+                    value: 6,
+                    errorMessage: 'number cannot be larger than 6'
+                }
+            }
+        });
+
+        var ComplicatedSchema = new SchemaObject({
+            number1: {
+                type: Number,
+                min: 5,
+            },
+            number2: {
+                type: Number,
+                min: [5, 'number cannot be smaller than 5'],
+            },
+            number3: {
+                type: Number,
+                min: {
+                    value: 5,
+                    errorMessage: 'number cannot be smaller than 5'
+                }
+            },
+            subObject: {
+                string1: {
+                    type: String,
+                    maxLength: 5
+                },
+                string2: {
+                    type: String,
+                    maxLength: [5, 'max length is 5']
+                },
+                string3: {
+                    type: String,
+                    maxLength: {
+                        value: 5,
+                        errorMessage: 'max length is 5'
+                    }
+                }
+            },
+            array1: [{
+                type: String,
+                maxLength: 5
+            }],
+            array2: [{
+                type: String,
+                maxLength: [5, 'max length is 5']
+            }],
+            array3: [{
+                type: String,
+                maxLength: {
+                    value: 5,
+                    errorMessage: 'max length is 5'
+                }
+            }],
+            arrayObject: [{
+                string1: {
+                    type: String,
+                    maxLength: 5
+                },
+                string2: {
+                    type: String,
+                    maxLength: [5, 'max length is 5']
+                },
+                string3: {
+                    type: String,
+                    maxLength: {
+                        value: 5,
+                        errorMessage: 'max length is 5'
+                    }
+                }
+            }]
+        });
+
         it('should return default min error', function () {
             var o = new SOD({
                 number: 1
@@ -1316,7 +1605,7 @@ describe('Number', function () {
 
         it('should return custom min error', function () {
             var o = new SOC({
-                number: 1
+                number: 1,
             });
             var errors = o.getErrors();
             errors.length.should.equal(1);
@@ -1338,7 +1627,7 @@ describe('Number', function () {
             errors[0].errorCode.should.equal(1222);
         });
 
-        it('should return custom max error', function () {
+        it('should return custom max error in array format', function () {
             var o = new SOC({
                 number: 7
             });
@@ -1348,6 +1637,92 @@ describe('Number', function () {
             errors[0].errorMessage.should.equal('number cannot be larger than 6');
             errors[0].errorType.should.equal('ValidationError');
             errors[0].errorCode.should.equal(1222);
+        });
+
+        it('should return custom max error in object format', function () {
+            var o = new SOO({
+                number: 7
+            });
+            var errors = o.getErrors();
+            errors.length.should.equal(1);
+
+            errors[0].errorMessage.should.equal('number cannot be larger than 6');
+            errors[0].errorType.should.equal('ValidationError');
+            errors[0].errorCode.should.equal(1222);
+        });
+
+        it('should handle both error formats as well as errors in sub-objects', function () {
+            var o = new ComplicatedSchema({
+                number1: 1,
+                number2: 2,
+                number3: 3,
+                subObject: {
+                    string1: 'longerThan5',
+                    string2: 'longerThan5Also',
+                    string3: 'longerThan5Too',
+                },
+                array1: ['longerThan5'],
+                array2: ['longerThan5'],
+                array3: ['longerThan5'],
+                arrayObject: [{
+                    string1: 'muchLongerThan5',
+                    string2: 'muchLongerThan5Also',
+                    string3: 'muchLongerThan5Too',
+                },{
+                    string1: 'good',
+                    string2: 'small',
+                    string3: 'tiny',
+                }]
+            });
+
+            var errors = o.getErrors();
+            //This number will increase by 3 once there is a fix for arrayObject errors not being populated
+            errors.length.should.equal(9);
+
+            //Top level default error
+            errors[0].errorMessage.should.equal('Number is too small to meet min requirement.');
+            errors[0].errorType.should.equal('ValidationError');
+            errors[0].errorCode.should.equal(1221);
+
+            //Top level custom error array
+            errors[1].errorMessage.should.equal('number cannot be smaller than 5');
+            errors[1].errorType.should.equal('ValidationError');
+            errors[1].errorCode.should.equal(1221);
+
+            //Top level custom error object
+            errors[2].errorMessage.should.equal('number cannot be smaller than 5');
+            errors[2].errorType.should.equal('ValidationError');
+            errors[2].errorCode.should.equal(1221);
+
+            //Sub-object default error
+            errors[3].errorMessage.should.equal('String length too long to meet maxLength requirement.');
+            errors[3].errorType.should.equal('ValidationError');
+            errors[3].errorCode.should.equal(1213);
+
+            //Sub-object custom error array
+            errors[4].errorMessage.should.equal('max length is 5');
+            errors[4].errorType.should.equal('ValidationError');
+            errors[4].errorCode.should.equal(1213);
+
+            //Sub-object custom error object
+            errors[5].errorMessage.should.equal('max length is 5');
+            errors[5].errorType.should.equal('ValidationError');
+            errors[5].errorCode.should.equal(1213);
+
+            //Array-string default error
+            errors[6].errorMessage.should.equal('String length too long to meet maxLength requirement.');
+            errors[6].errorType.should.equal('ValidationError');
+            errors[6].errorCode.should.equal(1213);
+
+            //Array-string custom error array
+            errors[7].errorMessage.should.equal('max length is 5');
+            errors[7].errorType.should.equal('ValidationError');
+            errors[7].errorCode.should.equal(1213);
+
+            //Array-string custom error object
+            errors[8].errorMessage.should.equal('max length is 5');
+            errors[8].errorType.should.equal('ValidationError');
+            errors[8].errorCode.should.equal(1213);
         });
     });
 


### PR DESCRIPTION
This is an update designed to allow custom messaging on validation errors, as well as introduce unique codes for each error type. This should address issue #14 

With this update each validator type now supports taking an array of arguments, for example instead of just declaring min and max like this:

```js
var SO = new SchemaObject({
  number: {
    type: Number,
    min: 5,
    max: 6
  }
});
```
You can now use an array if you would like to use a custom error message:
```js
var SO = new SchemaObject({
  number: {
    type: Number,
    min: [5, 'number cannot be smaller than 5'],
    max: [6, 'number cannot be larger than 6']
  }
});
```

The error output for each error is somewhat more verbose now that we have a concept of error classes. For example if we failed validation on the max on the previous example the output object would look like this:
```js
NumberMaxValidationError {
  errorMessage: 'Number is too big to meet max requirement.',
  setValue: 7,
  originalValue: undefined,
  fieldSchema: { type: 'number', min: 5, max: 6, name: 'number' },
  errorCode: 1222,
  errorType: 'ValidationError',
  schemaObject: SchemaObjectInstance { number: [Getter/Setter] }
}
```

Lastly I noticed that internationally formatted numbers may have issues with this library as it assumes the number separator is always a comma. I have added an option to expect decimal number separators if need be. For example if in the current version you created this schema:
```js
var SO = new SchemaObject({
  number: Number
});
```
And attempted:
```js
var so = new SO({ number: '124.423.123,87'});
console.log(so.number); //undefined
```
As you can see `so.number` would be undefined as that number format is not expected. Now if you are expecting users to submit decimal delimited numbers you can specify a new option `useDecimalNumberGroupSeparator` as true. For example:
```js
var SO = new SchemaObject({
  number: Number
}, {
  useDecimalNumberGroupSeparator: true
});
var so = new SO({ number: '124.423.123,87'});
console.log(so.number); //124423123.87
```

I think the only thing left is updating the readme documentation, I wasn't sure if you would want the validation error bit as part of the error section, or in each of the different validator type sections. Please let me know if you have any questions or comments.