### PR TITLE
fix TypeScript error TS4023 "using name 'SchemaObjectInstance'"

### DIFF
--- a/typescript/schemaobject.d.ts
+++ b/typescript/schemaobject.d.ts
@@ -1,22 +1,23 @@
+interface SchemaObjectInstance<T> {
+    populate(values: T): void;
+    toObject(): T;
+    clone(): SchemaObjectInstance<T>;
+    clear(): void;
+    getErrors(): Array<{
+        errorMessage: string;
+        setValue: any;
+        originalValue: any;
+        fieldSchema: {
+            name: string;
+            index: string;
+        }
+        schemaObject: SchemaObjectInstance<T>;
+    }>;
+    clearErrors(): void;
+    isErrors(): boolean;
+}
+
 declare module 'schema-object' {
-    interface SchemaObjectInstance<T> {
-        populate(values: T): void;
-        toObject(): T;
-        clone(): SchemaObjectInstance<T>;
-        clear(): void;
-        getErrors(): Array<{
-            errorMessage: string;
-            setValue: any;
-            originalValue: any;
-            fieldSchema: {
-                name: string;
-                index: string;
-            }
-            schemaObject: SchemaObjectInstance<T>;
-        }>;
-        clearErrors(): void;
-        isErrors(): boolean;
-    }
 
     interface SchemaObject {
         new <T>(schema: any, options?: any): {
@@ -25,4 +26,5 @@ declare module 'schema-object' {
     }
     const SO: SchemaObject;
     export = SO;
+
 }


### PR DESCRIPTION
error TS4023: Exported variable 'MyVariableName' has or is using name 'SchemaObjectInstance' from external module 'schema-object' but cannot be named.

This is because the interface is not exported from the module and is not globally accessible