### PR TITLE
Fix custom error messages disappearing

### DIFF
--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -520,7 +520,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
     function typecast(value, originalValue, properties) {
         var options = this[_privateKey]._options;
-        var customError = void 0;
 
         // Allow transform to manipulate raw properties.
         if (properties.transform) {
@@ -789,7 +788,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
                 // If the date couldn't be parsed, do not modify index.
                 if (value == 'Invalid Date' || !_.isDate(value)) {
-                    throw new DateParseValidationError(customError, value, originalValue, properties);
+                    throw new DateParseValidationError(null, value, originalValue, properties);
                 }
 
                 // Transformation after typecasting but before validation and filters.

--- a/dist/schemaobject.js
+++ b/dist/schemaobject.js
@@ -534,14 +534,18 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
         // Helper function designed to detect and handle usage of array-form custom error messages for validators
         function detectCustomErrorMessage(key) {
-            if (_.isArray(properties[key])) {
-                customError = properties[key][1];
-                properties[key] = properties[key][0];
-            } else if (_typeof(properties[key]) === 'object' && properties[key].errorMessage && properties[key].value) {
-                customError = properties[key].errorMessage;
-                properties[key] = properties[key].value;
+            if (_typeof(properties[key]) === 'object' && properties[key].errorMessage && properties[key].value) {
+                return properties[key];
+            } else if (_.isArray(properties[key])) {
+                return {
+                    value: properties[key][0],
+                    errorMessage: properties[key][1]
+                };
             } else {
-                customError = undefined;
+                return {
+                    value: properties[key],
+                    errorMessage: undefined
+                };
             }
         }
 
@@ -573,42 +577,50 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                     value = value.substr(0, properties.maxLength);
                 }
 
+                var enumValidation = void 0;
+
                 // Detect custom error message usage for enum (can't use function here as enum is expected to be an array)
-                if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
-                    customError = properties.enum[1];
-                    properties.enum = properties.enum[0];
-                } else if (_typeof(properties.enum) === 'object' && properties.enum.errorMessage && properties.enum.value) {
-                    customError = properties.enum.errorMessage;
-                    properties.enum = properties.enum.value;
+                if (_typeof(properties.enum) === 'object' && properties.enum.errorMessage && properties.enum.value) {
+                    enumValidation = properties.enum;
+                } else if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
+                    enumValidation = {
+                        value: properties.enum[0],
+                        errorMessage: properties.enum[1]
+                    };
+                } else {
+                    enumValidation = {
+                        value: properties.enum,
+                        errorMessage: undefined
+                    };
                 }
 
                 // If enum is being used, be sure the value is within definition.
-                if (_.isArray(properties.enum) && properties.enum.indexOf(value) === -1) {
-                    throw new StringEnumValidationError(customError, value, originalValue, properties);
+                if (enumValidation.value !== undefined && _.isArray(enumValidation.value) && enumValidation.value.indexOf(value) === -1) {
+                    throw new StringEnumValidationError(enumValidation.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for minLength
-                detectCustomErrorMessage('minLength');
+                var minLength = detectCustomErrorMessage('minLength');
 
                 // If minLength is defined, check to be sure the string is > minLength.
-                if (properties.minLength !== undefined && value.length < properties.minLength) {
-                    throw new StringMinLengthValidationError(customError, value, originalValue, properties);
+                if (minLength.value !== undefined && value.length < minLength.value) {
+                    throw new StringMinLengthValidationError(minLength.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for maxLength
-                detectCustomErrorMessage('maxLength');
+                var maxLength = detectCustomErrorMessage('maxLength');
 
                 // If maxLength is defined, check to be sure the string is < maxLength.
-                if (properties.maxLength !== undefined && value.length > properties.maxLength) {
-                    throw new StringMaxLengthValidationError(customError, value, originalValue, properties);
+                if (maxLength.value !== undefined && value.length > maxLength.value) {
+                    throw new StringMaxLengthValidationError(maxLength.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for maxLength
-                detectCustomErrorMessage('regex');
+                var regex = detectCustomErrorMessage('regex');
 
                 // If regex is defined, check to be sure the string matches the regex pattern.
-                if (properties.regex && !properties.regex.test(value)) {
-                    throw new StringRegexValidationError(customError, value, originalValue, properties);
+                if (regex.value && !regex.value.test(value)) {
+                    throw new StringRegexValidationError(regex.errorMessage, value, originalValue, properties);
                 }
 
                 return value;
@@ -660,17 +672,17 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                 }
 
                 // Detect custom error message usage for min
-                detectCustomErrorMessage('min');
+                var min = detectCustomErrorMessage('min');
 
-                if (properties.min !== undefined && value < properties.min) {
-                    throw new NumberMinValidationError(customError, value, originalValue, properties);
+                if (min.value !== undefined && value < min.value) {
+                    throw new NumberMinValidationError(min.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for min
-                detectCustomErrorMessage('max');
+                var max = detectCustomErrorMessage('max');
 
-                if (properties.max !== undefined && value > properties.max) {
-                    throw new NumberMaxValidationError(customError, value, originalValue, properties);
+                if (max.value !== undefined && value > max.value) {
+                    throw new NumberMaxValidationError(max.errorMessage, value, originalValue, properties);
                 }
 
                 return value;

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -311,16 +311,20 @@
 
         // Helper function designed to detect and handle usage of array-form custom error messages for validators
         function detectCustomErrorMessage(key) {
-            if (_.isArray(properties[key])) {
-                customError = properties[key][1];
-                properties[key] = properties[key][0];
+            if (typeof properties[key] === 'object' && properties[key].errorMessage && properties[key].value) {
+                return properties[key];
             }
-            else if (typeof properties[key] === 'object' && properties[key].errorMessage && properties[key].value) {
-                customError = properties[key].errorMessage;
-                properties[key] = properties[key].value;
+            else  if (_.isArray(properties[key])) {
+                return {
+                    value: properties[key][0],
+                    errorMessage: properties[key][1]
+                };
             }
             else {
-                customError = undefined;
+                return {
+                    value: properties[key],
+                    errorMessage: undefined
+                };
             }
         }
 
@@ -352,44 +356,56 @@
                     value = value.substr(0, properties.maxLength);
                 }
 
-                // Detect custom error message usage for enum (can't use function here as enum is expected to be an array)
-                if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
-                    customError = properties.enum[1];
-                    properties.enum = properties.enum[0];
-                }
-                else if (typeof properties.enum === 'object' && properties.enum.errorMessage && properties.enum.value) {
-                    customError = properties.enum.errorMessage;
-                    properties.enum = properties.enum.value;
-                }
+                let enumValidation;
 
+                // Detect custom error message usage for enum (can't use function here as enum is expected to be an array)
+                if (typeof properties.enum === 'object' && properties.enum.errorMessage && properties.enum.value) {
+                    enumValidation = properties.enum;
+                }
+                else if (_.isArray(properties.enum) && _.isArray(properties.enum[0])) {
+                    enumValidation = {
+                        value: properties.enum[0],
+                        errorMessage: properties.enum[1]
+                    };
+                }
+                else {
+                    enumValidation = {
+                        value: properties.enum,
+                        errorMessage: undefined
+                    };
+                }
 
                 // If enum is being used, be sure the value is within definition.
-                if (_.isArray(properties.enum) && properties.enum.indexOf(value) === -1) {
-                    throw new StringEnumValidationError(customError, value, originalValue, properties);
+                if (
+                    enumValidation.value !== undefined &&
+                    _.isArray(enumValidation.value) &&
+                    enumValidation.value.indexOf(value) === -1
+                ) {
+                    throw new StringEnumValidationError(enumValidation.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for minLength
-                detectCustomErrorMessage('minLength');
+                let minLength = detectCustomErrorMessage('minLength');
 
                 // If minLength is defined, check to be sure the string is > minLength.
-                if (properties.minLength !== undefined && value.length < properties.minLength) {
-                    throw new StringMinLengthValidationError(customError, value, originalValue, properties);
+                if (minLength.value !== undefined && value.length < minLength.value) {
+                    throw new StringMinLengthValidationError(minLength.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for maxLength
-                detectCustomErrorMessage('maxLength');
+                let maxLength = detectCustomErrorMessage('maxLength');
 
                 // If maxLength is defined, check to be sure the string is < maxLength.
-                if (properties.maxLength !== undefined && value.length > properties.maxLength) {
-                    throw new StringMaxLengthValidationError(customError, value, originalValue, properties);
+                if (maxLength.value !== undefined && value.length > maxLength.value) {
+                    throw new StringMaxLengthValidationError(maxLength.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for maxLength
-                detectCustomErrorMessage('regex');
+                let regex = detectCustomErrorMessage('regex');
 
                 // If regex is defined, check to be sure the string matches the regex pattern.
-                if (properties.regex && !properties.regex.test(value)) {
-                    throw new StringRegexValidationError(customError, value, originalValue, properties);
+                if (regex.value && !regex.value.test(value)) {
+                    throw new StringRegexValidationError(regex.errorMessage, value, originalValue, properties);
                 }
 
                 return value;
@@ -444,17 +460,17 @@
                 }
 
                 // Detect custom error message usage for min
-                detectCustomErrorMessage('min');
+                let min = detectCustomErrorMessage('min');
 
-                if (properties.min !== undefined && value < properties.min) {
-                    throw new NumberMinValidationError(customError, value, originalValue, properties);
+                if (min.value !== undefined && value < min.value) {
+                    throw new NumberMinValidationError(min.errorMessage, value, originalValue, properties);
                 }
 
                 // Detect custom error message usage for min
-                detectCustomErrorMessage('max');
+                let max = detectCustomErrorMessage('max');
 
-                if (properties.max !== undefined && value > properties.max) {
-                    throw new NumberMaxValidationError(customError, value, originalValue, properties);
+                if (max.value !== undefined && value > max.value) {
+                    throw new NumberMaxValidationError(max.errorMessage, value, originalValue, properties);
                 }
 
                 return value;

--- a/lib/schemaobject.js
+++ b/lib/schemaobject.js
@@ -297,7 +297,6 @@
     // Returns typecasted value if possible. If rejected, originalValue is returned.
     function typecast(value, originalValue, properties) {
         const options = this[_privateKey]._options;
-        let customError;
 
         // Allow transform to manipulate raw properties.
         if (properties.transform) {
@@ -577,7 +576,7 @@
 
                 // If the date couldn't be parsed, do not modify index.
                 if (value == 'Invalid Date' || !_.isDate(value)) {
-                    throw new DateParseValidationError(customError, value, originalValue, properties);
+                    throw new DateParseValidationError(null, value, originalValue, properties);
                 }
 
                 // Transformation after typecasting but before validation and filters.

--- a/test/tests.js
+++ b/test/tests.js
@@ -896,6 +896,14 @@ describe('String', function () {
 
             o.string = '1234';
             o.string.should.equal('ABCD');
+
+            //Should have the custom error when creating a second instance
+            var o2 = new SO({
+                string: 'abcd'
+            });
+            errors = o2.getErrors();
+            errors[0].errorMessage.should.equal('This can only contain capital letters A-Z, and must be 4 characters' +
+                ' long');
         });
 
         it('should handle custom errors in object format', function () {
@@ -1001,6 +1009,13 @@ describe('String', function () {
             errors[0].errorCode.should.equal(1211);
 
             o.isErrors().should.equal(true);
+
+            //Should have the custom error when creating a second instance
+            var o2 = new SO({
+                string: 'c'
+            });
+            errors = o2.getErrors();
+            errors[0].errorMessage.should.equal('Must be a or b');
         });
 
         it('should handle custom error in object format', function () {
@@ -1024,6 +1039,14 @@ describe('String', function () {
             errors[0].errorCode.should.equal(1211);
 
             o.isErrors().should.equal(true);
+
+            //Should have the custom error when creating a second instance
+            var o2 = new SO({
+                string: 'c'
+            });
+
+            errors = o2.getErrors();
+            errors[0].errorMessage.should.equal('Must be a or b');
         });
     });
 
@@ -1197,6 +1220,12 @@ describe('String', function () {
             errors[0].errorMessage.should.equal('shortString cannot be longer than 5 characters');
             errors[0].errorType.should.equal('ValidationError');
             errors[0].errorCode.should.equal(1213);
+
+            //Should have same custom error on second instance
+            var o2 = new SO();
+            o2.shortString = '123456';
+            errors = o2.getErrors();
+            errors[0].errorMessage.should.equal('shortString cannot be longer than 5 characters');
         });
     });
 


### PR DESCRIPTION
This fixes a bug in the custom error message code which causes custom error messages to only exist on the first instance of an object. This was due to the fact that the custom error code was  unintentionally modifying validation properties of schema by reference. While it wouldn't stop the validation from working properly, the custom message would be not be applied to future instances.

The fix is to no longer modify the schema in any way.