### PR TITLE
Adding type-check against interfaces for SchemaObject constructor

### DIFF
--- a/typescript/schemaobject.d.ts
+++ b/typescript/schemaobject.d.ts
@@ -20,7 +20,7 @@ interface SchemaObjectInstance<T> {
 declare module 'schema-object' {
 
     interface SchemaObject {
-        new <T>(schema: any, options?: any): {
+        new <T>(schema: { [key in keyof T]: any }, options?: any): {
             new (values?: T): T & SchemaObjectInstance<T>;
         };
     }


### PR DESCRIPTION
Adds type-checking instead of **any** so interface types are strictly respected. This way, specifying a type to **new** will show an error if a non-member is added into the schema.

With this feature, the following would generate an error:

```ts
interface MyType
{
    x: string;
    y: number;
}

const TypeSchema = new SchemaObject<MyType>({
    x: { type: String }, // Exists in MyType, all good
    y: { type: Number }, // Exists in MyType, all good
    z: { type: String } // Does not exist in MyType and will generate an error from TypeScript
});
```